### PR TITLE
Improvements to Linux support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ log = "0.4.16"
 env_logger = "0.9.0"
 thiserror = "1.0.30"
 
+['cfg(not(target_os = "linux"))'.dependencies]
+open = "2.1.1"
+
 [dependencies.serde]
 features = ["derive"]
 version = "1.0.136"

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,9 @@
 # default exec command when open files
 default = "nvim"
 
+# default text editor
+editor = "nvim"
+
 # key(command you want to use) = values(extensions)
 [exec]
 feh = ["jpg", "jpeg", "png", "gif", "svg"]

--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@
 default = "nvim"
 
 # default text editor
-editor = "nvim"
+# editor = "nvim"
 
 # key(command you want to use) = values(extensions)
 [exec]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ pub const CONFIG_EXAMPLE: &str = "
 default = \"nvim\"
 
 # default text editor
-editor = \"nvim\"
+# editor = \"nvim\"
 
 # key(command you want to use) = values(extensions)
 [exec]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
+use super::errors::MyError;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs::read_to_string;
-use super::errors::MyError;
 
 use crate::state::FX_CONFIG_DIR;
 
@@ -10,6 +10,9 @@ const CONFIG_FILE: &str = "config.toml";
 pub const CONFIG_EXAMPLE: &str = "
 # default exec command when open files
 default = \"nvim\"
+
+# default text editor
+editor = \"nvim\"
 
 # key(command you want to use) = values(extensions)
 [exec]
@@ -46,6 +49,7 @@ symlink_fg = \"LightYellow\"
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {
     pub default: String,
+    pub editor: Option<String>,
     pub exec: HashMap<String, Vec<String>>,
     pub color: Color,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -197,7 +197,9 @@ impl State {
                     }
 
                     #[cfg(not(target_os = "linux"))]
-                    None => &self.default,
+                    None => {
+                        return crate::open::that(path).map_err(MyError::IoError);
+                    }
                 }
             }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -153,6 +153,17 @@ impl State {
                         let mut ex = Command::new(command);
                         ex.arg(path).status().map_err(MyError::IoError)
                     }
+
+                    // Use xdg-open for opening files on Linux.
+                    #[cfg(target_os = "linux")]
+                    None => {
+                        Command::new("xdg-open")
+                            .arg(path)
+                            .status()
+                            .map_err(MyError::IoError)
+                    }
+
+                    #[cfg(not(target_os = "linux"))]
                     None => {
                         let mut ex = Command::new(&self.default);
                         ex.arg(path).status().map_err(MyError::IoError)

--- a/src/state.rs
+++ b/src/state.rs
@@ -105,8 +105,21 @@ impl Default for State {
 
         let mut editor = config.editor;
 
+        #[cfg(target_os = "linux")]
         if editor.is_none() {
-            editor = gitconfig_editor();
+            // Get editor from env var if set.
+            editor = std::env::var("EDITOR").ok();
+
+            // Get editor from debian alternatives if exists
+            const DEB_EDITOR: &str = "/usr/bin/editor";
+            if editor.is_none() && Path::new(DEB_EDITOR).exists() {
+                editor = Some(String::from(DEB_EDITOR));
+            }
+
+            // Get editor from gitconfig
+            if editor.is_none() {
+                editor = gitconfig_editor();
+            }
         }
 
         State {


### PR DESCRIPTION
- Use `xdg-open` when no default command is found
- Use `file` to identify if a file is text on Linux, and then choose the default text editor defined in the config if no default command was specified for its extension
- Automatically determine the default editor, starting with `EDITOR`, then `/usr/bin/editor`, then `.gitconfig`.