### PR TITLE
v0.9.1: Bug fix and preview feature updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@
 ### Notes
 - Text preview color needs to be readable enough, so it's worth rethinking (Now LightBlack).
 
-## v0.9.0 (2022-05-11)
+## v0.9.1 (2022-05-11)
+### Fixed
+- Fix bug that after `:h`, cursor move can cause unexpected panic.
+
+### Changed
+- Wrap preview text.
+
+## v0.9.0 (2022-05-10)
 ### Added
 - CHANGELOG.md
 - New command: `v` to toggle whether to show i) part of the content for text file (no wrapping and static), or ii) contents tree for directory. Note that this preview feature may not work effectively with small terminal.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "felix"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felix"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Kyohei Uto <kyoheiu@outlook.com>"]
 edition = "2021"
 description = "tui file manager with vim-like key mapping"

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ While heavliy inspired by the great `vifm` and trying to implement its pleasant 
 
 ## New Release
 
-v0.9.0 (2022-05-11)
-
-- New command: 'v' to toggle whether to show i) preview for text item, or ii) contents for directory. Note that this preview feature may not work effectively with small terminal.
+v0.9.1 (2022-05-11)
+- Fix bug that after `:h`, cursor move can cause unexpected panic.
+- Wrap preview text.
 
 For more detail, see `CHANGELOG.md`.
 

--- a/README_crates.md
+++ b/README_crates.md
@@ -13,9 +13,9 @@ While heavliy inspired by the great `vifm` and trying to implement its pleasant 
 
 ## New Release
 
-v0.9.0 (2022-05-11)
-
-- New command: 'v' to toggle whether to show i) preview for text item, or ii) contents for directory. Note that this preview feature may not work effectively with small terminal.
+v0.9.1 (2022-05-11)
+- Fix bug that after `:h`, cursor move can cause unexpected panic.
+- Wrap preview text.
 
 For more detail, see `CHANGELOG.md`.
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -373,7 +373,7 @@ mod tests {
         assert_eq!(
             format_txt(crate::help::HELP, 50, true),
             vec![
-                String::from("# felix v0.9.0"),
+                String::from("# felix v0.9.1"),
                 String::from("A simple TUI file manager with vim-like keymapping"),
                 String::from("."),
                 String::from("Works on terminals with 21 columns or more."),

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -266,7 +266,7 @@ pub fn make_tree(v: Vec<String>) -> Result<String, FxError> {
     Ok(result)
 }
 
-pub fn format_help(txt: &str, column: u16) -> Vec<String> {
+pub fn format_txt(txt: &str, column: u16) -> Vec<String> {
     let mut v = Vec::new();
     let mut column_count = 0;
     let mut line = String::new();
@@ -366,10 +366,10 @@ mod tests {
     }
 
     #[test]
-    fn test_format_help() {
-        println!("{:#?}", format_help(crate::help::HELP, 50));
+    fn test_format_txt() {
+        println!("{:#?}", format_txt(crate::help::HELP, 50));
         assert_eq!(
-            format_help(crate::help::HELP, 50),
+            format_txt(crate::help::HELP, 50),
             vec![
                 String::from("# felix v0.9.0"),
                 String::from("A simple TUI file manager with vim-like keymapping"),

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -266,7 +266,7 @@ pub fn make_tree(v: Vec<String>) -> Result<String, FxError> {
     Ok(result)
 }
 
-pub fn format_txt(txt: &str, column: u16) -> Vec<String> {
+pub fn format_txt(txt: &str, column: u16, is_help: bool) -> Vec<String> {
     let mut v = Vec::new();
     let mut column_count = 0;
     let mut line = String::new();
@@ -286,7 +286,9 @@ pub fn format_txt(txt: &str, column: u16) -> Vec<String> {
             continue;
         }
     }
-    v.push("Enter 'q' to go back.".to_string());
+    if is_help {
+        v.push("Enter 'q' to go back.".to_string());
+    }
     v
 }
 
@@ -367,9 +369,9 @@ mod tests {
 
     #[test]
     fn test_format_txt() {
-        println!("{:#?}", format_txt(crate::help::HELP, 50));
+        println!("{:#?}", format_txt(crate::help::HELP, 50, true));
         assert_eq!(
-            format_txt(crate::help::HELP, 50),
+            format_txt(crate::help::HELP, 50, true),
             vec![
                 String::from("# felix v0.9.0"),
                 String::from("A simple TUI file manager with vim-like keymapping"),

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,4 +1,4 @@
-pub const HELP: &str = "# felix v0.9.0
+pub const HELP: &str = "# felix v0.9.1
 A simple TUI file manager with vim-like keymapping.
 Works on terminals with 21 columns or more.
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -1167,7 +1167,7 @@ pub fn run(arg: PathBuf) -> Result<(), FxError> {
                                             cursor::Goto(1, 1)
                                         );
                                         screen.flush()?;
-                                        let help = format_help(HELP, state.layout.terminal_column);
+                                        let help = format_txt(HELP, state.layout.terminal_column);
                                         let help_len = help.clone().len();
                                         print_help(&help, 0, state.layout.terminal_row);
                                         screen.flush()?;

--- a/src/run.rs
+++ b/src/run.rs
@@ -1167,7 +1167,8 @@ pub fn run(arg: PathBuf) -> Result<(), FxError> {
                                             cursor::Goto(1, 1)
                                         );
                                         screen.flush()?;
-                                        let help = format_txt(HELP, state.layout.terminal_column);
+                                        let help =
+                                            format_txt(HELP, state.layout.terminal_column, true);
                                         let help_len = help.clone().len();
                                         print_help(&help, 0, state.layout.terminal_row);
                                         screen.flush()?;

--- a/src/run.rs
+++ b/src/run.rs
@@ -1177,9 +1177,12 @@ pub fn run(arg: PathBuf) -> Result<(), FxError> {
                                             if let Some(Ok(key)) = stdin.next() {
                                                 match key {
                                                     Key::Char('j') | Key::Down => {
-                                                        if skip
-                                                            == help_len + 1
-                                                                - state.layout.terminal_row as usize
+                                                        if help_len
+                                                            < state.layout.terminal_row.into()
+                                                            || skip
+                                                                == help_len + 1
+                                                                    - state.layout.terminal_row
+                                                                        as usize
                                                         {
                                                             continue;
                                                         } else {


### PR DESCRIPTION
v0.9.1 (2022-05-11)
## Fixed
- Fix bug that after `:h`, cursor move can cause unexpected panic.

## Changed
- Wrap preview text.