### PR TITLE
v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- In the filter mode, if you don't have any input, `backspace` now means to return to the normal mode. Also, if you press `Esc` during the filter mode, the cursor position is now restored.
+- In the filter mode and shell mode, if you don't have any input, `backspace` now means to return to the normal mode. Also, if you press `Esc` during the filter mode, the cursor position is now restored.
 
 ## v1.1.0 (2022-08-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- In the filter mode, if you don't have any input, `backspace` now means to return to the normal mode. Also, if you press `Esc` during the filter mode, the cursor position is now restored.
+
 ## v1.1.0 (2022-08-08)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 ## [Unreleased]
 
+## v1.1.1 (2022-08-11)
+
 ### Fixed
 
-- In the filter mode and shell mode, if you don't have any input, `backspace` now means to return to the normal mode. Also, if you press `Esc` during the filter mode, the cursor position is now restored.
+- In the filter mode and shell mode, when you don't have any input, `backspace` now means to return to the normal mode. Also, when you press `Esc` during the filter mode, the cursor position is now restored.
 
 ## v1.1.0 (2022-08-08)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "felix"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "chrono",
  "content_inspector",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felix"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Kyohei Uto <kyoheiu@outlook.com>"]
 edition = "2021"
 description = "tui file manager with vim-like key mapping"

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-# 1.1.0
+# 1.1.1
 
 # Default exec command when open files.
 default = "nvim"

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,5 +1,5 @@
 /// Help text.
-pub const HELP: &str = "# felix v1.1.0
+pub const HELP: &str = "# felix v1.1.1
 A simple TUI file manager with vim-like keymapping.
 
 ## Usage

--- a/src/run.rs
+++ b/src/run.rs
@@ -1230,18 +1230,22 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
 
                                 Key::Backspace => {
                                     if current_pos == initial_pos {
-                                        continue;
-                                    };
-                                    command.remove((current_pos - initial_pos - 1).into());
-                                    current_pos -= 1;
+                                        reset_info_line();
+                                        print!("{}", cursor::Hide);
+                                        state.move_cursor(&nums, y);
+                                        break 'command;
+                                    } else {
+                                        command.remove((current_pos - initial_pos - 1).into());
+                                        current_pos -= 1;
 
-                                    print!(
-                                        "{}{}:{}{}",
-                                        clear::CurrentLine,
-                                        cursor::Goto(2, 2),
-                                        &command.iter().collect::<String>(),
-                                        cursor::Goto(current_pos, 2)
-                                    );
+                                        print!(
+                                            "{}{}:{}{}",
+                                            clear::CurrentLine,
+                                            cursor::Goto(2, 2),
+                                            &command.iter().collect::<String>(),
+                                            cursor::Goto(current_pos, 2)
+                                        );
+                                    }
                                 }
 
                                 Key::Char('\n') => {

--- a/src/run.rs
+++ b/src/run.rs
@@ -1086,7 +1086,6 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
                     screen.flush()?;
 
                     let original_list = state.list.clone();
-
                     let mut keyword: Vec<char> = Vec::new();
                     let initial_pos = 3;
                     let mut current_pos = 3;
@@ -1107,7 +1106,7 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
                                     print!("{}", cursor::Hide);
                                     state.filtered = false;
                                     state.list = original_list;
-                                    state.redraw(&nums, y);
+                                    state.reload(&nums, y)?;
                                     break;
                                 }
 
@@ -1125,6 +1124,39 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
                                     }
                                     current_pos += 1;
                                     print!("{}", cursor::Right(1));
+                                }
+
+                                Key::Backspace => {
+                                    if current_pos == initial_pos {
+                                        print!("{}", cursor::Hide);
+                                        state.filtered = false;
+                                        state.list = original_list;
+                                        state.reload(&nums, y)?;
+                                        break;
+                                    } else {
+                                        keyword.remove(current_pos - initial_pos - 1);
+                                        current_pos -= 1;
+
+                                        state.list = original_list
+                                            .clone()
+                                            .into_iter()
+                                            .filter(|entry| {
+                                                entry
+                                                    .file_name
+                                                    .contains(&keyword.iter().collect::<String>())
+                                            })
+                                            .collect();
+
+                                        state.clear_and_show_headline();
+                                        state.list_up(0);
+
+                                        print!(
+                                            "{}/{}{}",
+                                            cursor::Goto(2, 2),
+                                            &keyword.iter().collect::<String>(),
+                                            cursor::Goto((current_pos).try_into().unwrap(), 2)
+                                        );
+                                    }
                                 }
 
                                 Key::Char(c) => {
@@ -1146,35 +1178,6 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
                                         "{}/{}{}",
                                         cursor::Goto(2, 2),
                                         result,
-                                        cursor::Goto((current_pos).try_into().unwrap(), 2)
-                                    );
-                                }
-
-                                Key::Backspace => {
-                                    if current_pos == initial_pos {
-                                        continue;
-                                    };
-                                    keyword.remove(current_pos - initial_pos - 1);
-                                    current_pos -= 1;
-
-                                    state.list = original_list
-                                        .clone()
-                                        .into_iter()
-                                        .filter(|entry| {
-                                            entry
-                                                .file_name
-                                                .contains(&keyword.iter().collect::<String>())
-                                        })
-                                        .collect();
-
-                                    nums.reset_skip();
-                                    state.clear_and_show_headline();
-                                    state.list_up(nums.skip);
-
-                                    print!(
-                                        "{}/{}{}",
-                                        cursor::Goto(2, 2),
-                                        &keyword.iter().collect::<String>(),
                                         cursor::Goto((current_pos).try_into().unwrap(), 2)
                                     );
                                 }


### PR DESCRIPTION
### Fixed

- In the filter mode and shell mode, when you don't have any input, `backspace` now means to return to the normal mode. Also, when you press `Esc` during the filter mode, the cursor position is now restored.