### PR TITLE
Editor env vars resolves kyoheiu/felix#110

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 # 1.2.0
 
-# Default exec command when open files.
+# (Optional) Default exec command when open files.
+# If not set, will default to $EDITOR
 default = "nvim"
 
 # (Optional) Whether to use the full width of terminal.

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,22 +120,73 @@ pub fn make_config_if_not_exist(config_file: &Path, trash_dir: &Path) -> Result<
         let stdin = std::io::stdin();
         stdin.read_line(&mut buffer)?;
 
-        let trimmed = buffer.trim();
-        let config = CONFIG_EXAMPLE.replace("nvim", trimmed);
-        std::fs::write(&config_file, config)
-            .unwrap_or_else(|_| panic!("cannot write new config file."));
-        if cfg!(target_os = "mac_os") {
-            println!(
+        let mut trimmed = buffer.trim();
+        if trimmed.is_empty() {
+            match std::env::var("EDITOR") {
+                Ok(_) => {
+                    let config = CONFIG_EXAMPLE.replace("default = \"nvim\"", "# default = \"\"");
+                    std::fs::write(&config_file, config)
+                        .unwrap_or_else(|_| panic!("Cannot write new config file."));
+                    if cfg!(target_os = "mac_os") {
+                        println!(
+                "Config file created.\nSee ~/Library/Application Support/felix/config.toml");
+                    } else if cfg!(target_os = "windows") {
+                        println!(
+                            "Config file created.\nSee ~\\AppData\\Roaming\\felix\\config.toml"
+                        );
+                    } else {
+                        println!("Config file created.\nSee ~/.config/felix/config.toml");
+                    }
+                }
+                Err(_) => {
+                    while trimmed.is_empty() {
+                        println!("Cannot detect $EDITOR: Enter your default command.");
+                        buffer = String::new();
+                        std::io::stdin().read_line(&mut buffer)?;
+                        trimmed = buffer.trim();
+                    }
+                    let config = CONFIG_EXAMPLE.replace("nvim", trimmed);
+                    std::fs::write(&config_file, config)
+                        .unwrap_or_else(|_| panic!("cannot write new config file."));
+                    if cfg!(target_os = "mac_os") {
+                        println!(
                 "Default command set as [{}].\nSee ~/Library/Application Support/felix/config.toml",
                 trimmed
             );
-        } else {
-            println!(
-                "Default command set as [{}].\nSee ~/.config/felix/config.toml",
+                    } else if cfg!(target_os = "windows") {
+                        println!(
+                "Default command set as [{}].\nSee ~\\AppData\\Roaming\\felix\\config.toml",
                 trimmed
             );
+                    } else {
+                        println!(
+                            "Default command set as [{}].\nSee ~/.config/felix/config.toml",
+                            trimmed
+                        );
+                    }
+                }
+            }
+        } else {
+            let config = CONFIG_EXAMPLE.replace("nvim", trimmed);
+            std::fs::write(&config_file, config)
+                .unwrap_or_else(|_| panic!("cannot write new config file."));
+            if cfg!(target_os = "mac_os") {
+                println!(
+                "Default command set as [{}].\nSee ~/Library/Application Support/felix/config.toml",
+                trimmed
+            );
+            } else if cfg!(target_os = "windows") {
+                println!(
+                    "Default command set as [{}].\nSee ~\\AppData\\Roaming\\felix\\config.toml",
+                    trimmed
+                );
+            } else {
+                println!(
+                    "Default command set as [{}].\nSee ~/.config/felix/config.toml",
+                    trimmed
+                );
+            }
         }
     }
-
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,7 +57,7 @@ symlink_fg = \"LightYellow\"
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {
-    pub default: String,
+    pub default: Option<String>,
     pub exec: Option<HashMap<String, Vec<String>>>,
     pub color: Color,
     pub use_full_width: Option<bool>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,6 +15,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::{Child, Command, ExitStatus, Stdio};
 use termion::{clear, color, cursor, style};
+use std::env;
 
 pub const BEGINNING_ROW: u16 = 3;
 pub const FX_CONFIG_DIR: &str = "felix";
@@ -136,7 +137,7 @@ impl State {
             },
             current_dir: PathBuf::new(),
             trash_dir: PathBuf::new(),
-            default: config.default,
+            default: config.default.unwrap_or_else(|| env::var("EDITOR").expect("")),
             commands: to_extension_map(&config.exec),
             sort_by: session.sort_by,
             layout: Layout {

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,12 +10,12 @@ use chrono::prelude::*;
 use log::{error, info};
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::env;
 use std::fmt::Write as _;
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Child, Command, ExitStatus, Stdio};
 use termion::{clear, color, cursor, style};
-use std::env;
 
 pub const BEGINNING_ROW: u16 = 3;
 pub const FX_CONFIG_DIR: &str = "felix";
@@ -137,7 +137,9 @@ impl State {
             },
             current_dir: PathBuf::new(),
             trash_dir: PathBuf::new(),
-            default: config.default.unwrap_or_else(|| env::var("EDITOR").expect("")),
+            default: config
+                .default
+                .unwrap_or_else(|| env::var("EDITOR").expect("Falling back to env var")),
             commands: to_extension_map(&config.exec),
             sort_by: session.sort_by,
             layout: Layout {


### PR DESCRIPTION
Removes the need for a default option and will pull from the shells $EDITOR variable as default, which seems to be a sane default based on the original config's intent.