### PR TITLE
Show cursor on exit

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -1602,6 +1602,7 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
 
     //Back to normal mode
     disable_raw_mode()?;
+    show_cursor();
     info!("===FINISH===");
     Ok(())
 }


### PR DESCRIPTION
Partially fixes #119, on a panic the terminal is still broken.

Tested on MacOS iTerm2 and VSCode terminal.