### PR TITLE
Preview: handle unresolved symlinks, handle failed content read

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -35,6 +35,8 @@ pub struct Layout {
 }
 
 pub enum PreviewType {
+    NotReadable,
+    UnresolvedSymlink,
     TooBigSize,
     Directory,
     Image,
@@ -51,8 +53,14 @@ impl Layout {
         self.clear_preview(self.preview_start_column);
 
         match check_preview_type(item) {
+            PreviewType::NotReadable => {
+                print!("(file not readable)");
+            }
+            PreviewType::UnresolvedSymlink => {
+                print!("(unresolved symlink)");
+            }
             PreviewType::TooBigSize => {
-                print!("(Too big size to preview)");
+                print!("(file too big for preview)");
             }
             PreviewType::Directory => {
                 self.preview_content(item, true);
@@ -223,21 +231,27 @@ pub fn make_layout(
 fn check_preview_type(item: &ItemInfo) -> PreviewType {
     if item.file_size > MAX_SIZE_TO_PREVIEW {
         PreviewType::TooBigSize
-    } else if item.file_type == FileType::Directory
-        || (item.file_type == FileType::Symlink && item.symlink_dir_path.is_some())
-    {
+    } else if item.file_type == FileType::Directory {
         PreviewType::Directory
+    } else if item.file_type == FileType::Symlink {
+        if item.symlink_dir_path.is_some() {
+            // assmuning symlink to be a directory
+            PreviewType::Directory
+        } else {
+            PreviewType::UnresolvedSymlink
+        }
     } else if is_supported_ext(item) {
         PreviewType::Image
     } else {
-        let content_type = content_inspector::inspect(
-            &std::fs::read(&item.file_path)
-                .unwrap_or_else(|_| panic!("failed check preview type.")),
-        );
-        if content_type.is_text() {
-            PreviewType::Text
+        if let Ok(content) = &std::fs::read(&item.file_path) {
+            let content_type = content_inspector::inspect(&content);
+            if content_type.is_text() {
+                PreviewType::Text
+            } else {
+                PreviewType::Binary
+            }
         } else {
-            PreviewType::Binary
+            PreviewType::NotReadable
         }
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -243,9 +243,9 @@ fn check_preview_content_type(item: &ItemInfo) -> PreviewType {
 
 /// Check preview type.
 fn check_preview_type(item: &ItemInfo) -> PreviewType {
-    if item.file_type == FileType::Directory {
-        PreviewType::Directory
-    } else if item.file_type == FileType::Symlink && item.symlink_dir_path.is_some() {
+    if item.file_type == FileType::Directory
+        || (item.file_type == FileType::Symlink && item.symlink_dir_path.is_some())
+    {
         // symlink was resolved to directory already in the ItemInfo
         PreviewType::Directory
     } else {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -237,22 +237,25 @@ fn check_preview_type(item: &ItemInfo) -> PreviewType {
         if item.symlink_dir_path.is_some() {
             // assmuning symlink to be a directory
             PreviewType::Directory
-        } else {
-            PreviewType::UnresolvedSymlink
-        }
-    } else if is_supported_ext(item) {
-        PreviewType::Image
-    } else {
-        if let Ok(content) = &std::fs::read(&item.file_path) {
-            let content_type = content_inspector::inspect(&content);
-            if content_type.is_text() {
+        } else if let Ok(content) = &std::fs::read(&item.file_path) {
+            if content_inspector::inspect(content).is_text() {
                 PreviewType::Text
             } else {
                 PreviewType::Binary
             }
         } else {
-            PreviewType::NotReadable
+            PreviewType::UnresolvedSymlink
         }
+    } else if is_supported_ext(item) {
+        PreviewType::Image
+    } else if let Ok(content) = &std::fs::read(&item.file_path) {
+        if content_inspector::inspect(content).is_text() {
+            PreviewType::Text
+        } else {
+            PreviewType::Binary
+        }
+    } else {
+        PreviewType::NotReadable
     }
 }
 


### PR DESCRIPTION
The proposed changes implement a more graceful handling of preview for non-readable files and circular symlinks.

* handles symlinks as directories (similarly as before)
* but only if the symlink path is set (which can be unset for circular symlinks)
* avoids file read panic and shows `(file not readable)` instead

tested with the following files
```
permissions     file                   preview

--w-------      denied.txt             (cannot read file)
lrwxr-xr-x      link -> some-dir       # shows files in the dir
drwxr-xr-x      some-dir               # shows files in the dir
lrwxr-xr-x      self -> self-link      (unresolved symlink)
lrwxr-xr-x      self-link -> self      (unresolved symlink)
```