### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ## Unreleased
 
-## v2.2.0 (2022-12-10)
+## v2.2.0 (2022-12-12)
 
 ### Changed
 
-- IMPORTANT: Trash and log directory path changed: from v2.2.0, felix will use `data_local_dir()` to store the deleted items and log files, instead of `config_dir()`. Due to this change, the path for linux will be `$XDG_DATA_HOME/felix/{Trash, log}`, in most case `/home/user/.local/share/felix/{Trash, log}`. For Windows `{FOLDERID_LocalAppData}\felix\{Trash, log}`, in most case `C:\Users\user\AppData\Local\felix\{Trash, log}`. No change for macOS users. Note that config file path is not changed.
+- IMPORTANT: Trash and log directory path changed.
+  - from v2.2.0, felix will use `dirs::data_local_dir()` to store the deleted items and log files, instead of `dirs::config_dir()`.
+  - Due to this change, the path for linux will be `$XDG_DATA_HOME/felix/{Trash, log}`, in most case `/home/user/.local/share/felix/{Trash, log}`. For Windows `{FOLDERID_LocalAppData}\felix\{Trash, log}`, in most case `C:\Users\user\AppData\Local\felix\{Trash, log}`. No change for macOS users. Note that config file path is not changed!
+  - Please don't forget deleting old trash diretory and log files if you don't want them anymore.
+- Refactoring overall.
 
 ### Added
 
@@ -17,7 +21,7 @@
 ### Fixed
 
 - Support NetBSD to open file in a new window.
-- Properly remove broken symlink in Windows as well. Also, when deleting/puttiing a directory, broken symlink(s) inside it won't cause any error and remove from the file system after deleting/putting.
+- Properly remove broken symlink in Windows as well. Also, when deleting/puttiing a directory, broken symlink(s) in it won't cause any error and will be removed from the file system after deleting/putting.
 
 ## v2.1.1 (2022-12-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Some refactoring around text-printing in the preview space.
 - When you change the sort key, felix refresh the list more efficiently than ever by avoiding to read all the items.
+- Item order(Name): Case-insensitive instead of sensitive.
 
 ## v2.1.0 (2022-11-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## Unreleased
 
+## v2.2.0 (2022-12-10)
+
+### Changed
+
+- IMPORTANT: Trash and log directory path changed: from v2.2.0, felix will use `data_local_dir()` to store the deleted items and log files, instead of `config_dir()`. Due to this change, the path for linux will be `$XDG_DATA_HOME/felix/{Trash, log}`, in most case `/home/user/.local/share/felix/{Trash, log}`. For Windows `{FOLDERID_LocalAppData}\felix\{Trash, log}`, in most case `C:\Users\user\AppData\Local\felix\{Trash, log}`. No change for macOS users. Note that config file path is not changed.
+
+### Fixed
+
+- Support NetBSD to open file in a new window.
+- Properly remove broken symlink in Windows as well. Also, when deleting/puttiing a directory, broken symlink(s) inside it won't cause any error and remove from the file system after deleting/putting.
+
 ## v2.1.1 (2022-12-02)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
 
 ### Changed
 
-- IMPORTANT: Trash and log directory path changed.
+- **IMPORTANT**: Trash and log directory path changed.
   - from v2.2.0, felix will use `dirs::data_local_dir()` to store the deleted items and log files, instead of `dirs::config_dir()`.
-  - Due to this change, the path for linux will be `$XDG_DATA_HOME/felix/{Trash, log}`, in most case `/home/user/.local/share/felix/{Trash, log}`. For Windows `{FOLDERID_LocalAppData}\felix\{Trash, log}`, in most case `C:\Users\user\AppData\Local\felix\{Trash, log}`. No change for macOS users. Note that config file path is not changed!
+  - Due to this change, the path for linux will be `$XDG_DATA_HOME/felix/{Trash, log}`, in most case `/home/user/.local/share/felix/{Trash, log}`. For Windows `{FOLDERID_LocalAppData}\felix\{Trash, log}`, typically `C:\Users\user\AppData\Local\felix\{Trash, log}`. No change for macOS users.
+  - Note that config file path is unchanged for any OS!
   - Please don't forget deleting old trash diretory and log files if you don't want them anymore.
 - Refactoring overall.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - IMPORTANT: Trash and log directory path changed: from v2.2.0, felix will use `data_local_dir()` to store the deleted items and log files, instead of `config_dir()`. Due to this change, the path for linux will be `$XDG_DATA_HOME/felix/{Trash, log}`, in most case `/home/user/.local/share/felix/{Trash, log}`. For Windows `{FOLDERID_LocalAppData}\felix\{Trash, log}`, in most case `C:\Users\user\AppData\Local\felix\{Trash, log}`. No change for macOS users. Note that config file path is not changed.
 
+### Added
+
+- `:trash` to go to the trash directory.
+
 ### Fixed
 
 - Support NetBSD to open file in a new window.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -277,15 +277,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "felix"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "content_inspector",
@@ -348,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
  "cfg-if",
  "libc",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "line-wrap"
@@ -571,9 +571,9 @@ checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
 name = "nix"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
  "bitflags",
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -802,18 +802,18 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -921,9 +921,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felix"
-version = "2.1.1"
+version = "2.2.0"
 authors = ["Kyohei Uto <im@kyoheiu.dev>"]
 edition = "2021"
 description = "tui file manager with vim-like key mapping"

--- a/README.md
+++ b/README.md
@@ -5,12 +5,23 @@
 A tui file manager with Vim-like key mapping, written in Rust.  
 Fast, simple, and easy to configure & use.
 
-For an overview of this app, please see this README, especially [key manual](#key).  
+For an overview of this app, take a look at this README, especially [key manual](#key-manual).  
 For more detailed document, visit https://kyoheiu.dev/felix.
+
+- [New release](#new-release)
+- [Status](#status)
+- [Installation](#installation)
+- [Integrations](#integrations)
+- [Usage](#usage)
+  - [Key manual](#key-manual)
+- [Preview feature](#preview)
+- [Configuration](#configuration)
 
 ![sample](screenshots/sample.gif)
 
-## New Release
+<a id="new-release"></a>
+
+## New release
 
 ## v2.2.0 (2022-12-12)
 
@@ -33,6 +44,8 @@ For more detailed document, visit https://kyoheiu.dev/felix.
 
 For more details, see `CHANGELOG.md`.
 
+<a id="status"></a>
+
 ## Status
 
 | OS      | Status               |
@@ -43,6 +56,8 @@ For more details, see `CHANGELOG.md`.
 | Windows | not fully tested yet |
 
 _For Windows users: From v1.3.0, it can be at least compiled on Windows (see `.github/workflows/install_test.yml`.) If you're interested, please try and report any problems._
+
+<a id="installation"></a>
 
 ## Installation
 
@@ -85,6 +100,8 @@ cd felix
 cargo install --path .
 ```
 
+<a id="integrations"></a>
+
 ## Integrations
 
 In addition, you can use felix more conveniently by installing these two apps:
@@ -94,6 +111,8 @@ In addition, you can use felix more conveniently by installing these two apps:
 
 These apps do not need any configuration to use with felix!
 
+<a id="usage"></a>
+
 ## Usage
 
 ```
@@ -102,7 +121,7 @@ These apps do not need any configuration to use with felix!
 Both relative and absolute path available.
 ```
 
-## Options
+### Options
 
 ```
 `-h` | `--help` => Print help.
@@ -110,9 +129,9 @@ Both relative and absolute path available.
 `-l [path]` | `--log [path]` => Launch the app and create a log file.
 ```
 
-<a id="key"></a>
+<a id="key-manual"></a>
 
-## Key Manual
+### Key manual
 
 ```
 j / Down          :Go down.
@@ -154,10 +173,14 @@ Esc               :Return to the normal mode.
 :q / ZZ           :Exit.
 ```
 
+<a id="preview"></a>
+
 ## Preview feature
 
 By default, text files and directories can be previewed.  
 Install `chafa` and you can preview images without any configuration.
+
+<a id="configuration"></a>
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 # _felix_
 
-A tui file manager with vim-like key mapping, written in Rust.  
+A tui file manager with Vim-like key mapping, written in Rust.  
 Fast, simple, and easy to configure & use.
 
-For the detailed document, please see https://kyoheiu.dev/felix.
+For an overview of this app, please see this README, especially [key manual](#key).  
+For more detailed document, visit https://kyoheiu.dev/felix.
 
 ![sample](screenshots/sample.gif)
 
@@ -17,7 +18,8 @@ For the detailed document, please see https://kyoheiu.dev/felix.
 
 - **IMPORTANT**: Trash and log directory path changed.
   - from v2.2.0, felix will use `dirs::data_local_dir()` to store the deleted items and log files, instead of `dirs::config_dir()`.
-  - Due to this change, the path for linux will be `$XDG_DATA_HOME/felix/{Trash, log}`, in most case `/home/user/.local/share/felix/{Trash, log}`. For Windows `{FOLDERID_LocalAppData}\felix\{Trash, log}`, in most case `C:\Users\user\AppData\Local\felix\{Trash, log}`. No change for macOS users. Note that config file path is not changed!
+  - Due to this change, the path for linux will be `$XDG_DATA_HOME/felix/{Trash, log}`, in most case `/home/user/.local/share/felix/{Trash, log}`. For Windows `{FOLDERID_LocalAppData}\felix\{Trash, log}`, typically `C:\Users\user\AppData\Local\felix\{Trash, log}`. No change for macOS users.
+  - Note that config file path is unchanged for any OS!
   - Please don't forget deleting old trash diretory and log files if you don't want them anymore.
 
 ### Added
@@ -69,7 +71,7 @@ yay -S felix-rs
 
 ### NetBSD
 
-available from the official repositories:
+Available from the official repositories.
 
 ```
 pkgin install felix
@@ -107,6 +109,8 @@ Both relative and absolute path available.
 `-v` | `--version` => Check update.
 `-l [path]` | `--log [path]` => Launch the app and create a log file.
 ```
+
+<a id="key"></a>
 
 ## Key Manual
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Install `chafa` and you can preview images without any configuration.
 
 ```
 config file     : $XDG_CONFIG_HOME/felix/config.yaml
-trash directory : $XDG_DATA_HOME/felix/trash
+trash directory : $XDG_DATA_HOME/felix/Trash
 log files       : $XDG_DATA_HOME/felix/log
 ```
 
@@ -158,7 +158,7 @@ log files       : $XDG_DATA_HOME/felix/log
 
 ```
 config file     : $HOME/Library/Application Support/felix/config.yaml
-trash directory : $HOME/Library/Application Support/felix/trash
+trash directory : $HOME/Library/Application Support/felix/Trash
 log files       : $HOME/Library/Application Support/felix/log
 ```
 
@@ -166,7 +166,7 @@ log files       : $HOME/Library/Application Support/felix/log
 
 ```
 config file     : $PROFILE\AppData\Roaming\felix\config.yaml
-trash directory : $PROFILE\AppData\Local\felix\trash
+trash directory : $PROFILE\AppData\Local\felix\Trash
 log files       : $PROFILE\AppData\Local\felix\log
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Install `chafa` and you can preview images without any configuration.
 
 ```
 config file     : $XDG_CONFIG_HOME/felix/config.yaml
-trash directory : $XDG_CONFIG_HOME/felix/trash
-log files       : \$XDG_CONFIG_HOME/felix/log
+trash directory : $XDG_DATA_HOME/felix/trash
+log files       : $XDG_DATA_HOME/felix/log
 ```
 
 ### macOS
@@ -159,15 +159,15 @@ log files       : \$XDG_CONFIG_HOME/felix/log
 ```
 config file     : $HOME/Library/Application Support/felix/config.yaml
 trash directory : $HOME/Library/Application Support/felix/trash
-log files       : \$HOME/Library/Application Support/felix/log
+log files       : $HOME/Library/Application Support/felix/log
 ```
 
 ### Windows
 
 ```
 config file     : $PROFILE\AppData\Roaming\felix\config.yaml
-trash directory : $PROFILE\AppData\Roaming\felix\trash
-log files       : $PROFILE\AppData\Roaming\felix\log
+trash directory : $PROFILE\AppData\Local\felix\trash
+log files       : $PROFILE\AppData\Local\felix\log
 ```
 
 For more details, visit https://kyoheiu.dev/felix.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Esc               :Return to the normal mode.
 :cd / :z          :Go to the home directory.
 :z <keyword>      :Same as `z <keyword>`.
 :e                :Reload the current directory.
+:trash            :Go to the trash directory.
 :empty            :Empty the trash directory.
 :h                :Show help.
 :q / ZZ           :Exit.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,23 @@ For the detailed document, please see https://kyoheiu.dev/felix.
 
 ## New Release
 
-## v2.1.1 (2022-12-02)
+## v2.2.0 (2022-12-12)
+
+### Changed
+
+- **IMPORTANT**: Trash and log directory path changed.
+  - from v2.2.0, felix will use `dirs::data_local_dir()` to store the deleted items and log files, instead of `dirs::config_dir()`.
+  - Due to this change, the path for linux will be `$XDG_DATA_HOME/felix/{Trash, log}`, in most case `/home/user/.local/share/felix/{Trash, log}`. For Windows `{FOLDERID_LocalAppData}\felix\{Trash, log}`, in most case `C:\Users\user\AppData\Local\felix\{Trash, log}`. No change for macOS users. Note that config file path is not changed!
+  - Please don't forget deleting old trash diretory and log files if you don't want them anymore.
+
+### Added
+
+- `:trash` to go to the trash directory.
 
 ### Fixed
 
-- You can now open a file in a new window on Wayland environment too.
-- Proper handling of wide characters: Even if e.g. file name includes some wide charatcters such as CJK, the layout won't break anymore.
-- Fix cursor color after printing the text preview.
+- Support NetBSD to open file in a new window.
+- Properly remove broken symlink in Windows as well. Also, when deleting/puttiing a directory, broken symlink(s) in it won't cause any error and will be removed from the file system after deleting/putting.
 
 For more details, see `CHANGELOG.md`.
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,12 +1,12 @@
 # v2.1.1
 
 # (Optional)
-# Default exec command when opening files.
+# Default exec command when opening file.
 # If not set, will default to $EDITOR.
 # default: nvim
 
 # (Optional)
-# key (the command you want to use when opening certain files): [values] (extensions)
+# key (the command you want to use when opening file): [values] (extensions)
 # exec:
 #   feh:
 #     [jpg, jpeg, png, gif, svg]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use super::errors::FxError;
-use super::state::FX_CONFIG_DIR;
+use super::state::FELIX;
 
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -200,7 +200,7 @@ pub fn make_config_if_not_exists(config_file: &Path, trash_dir: &Path) -> Result
 fn config_file_path() -> Result<PathBuf, FxError> {
     let mut config =
         dirs::config_dir().ok_or_else(|| FxError::Dirs("Cannot read config dir.".to_string()))?;
-    config.push(FX_CONFIG_DIR);
+    config.push(FELIX);
     config.push(CONFIG_FILE);
     Ok(config)
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,3 +1,5 @@
+use crate::state::FELIX;
+
 use super::config::Colorname;
 use super::errors::FxError;
 use super::term::*;
@@ -256,14 +258,19 @@ pub fn is_editable(s: &str) -> bool {
 }
 
 /// Initialize the log if `-l` option is added.
-pub fn init_log(config_dir_path: &Path) -> Result<(), FxError> {
+pub fn init_log(data_local_path: &Path) -> Result<(), FxError> {
     let mut log_name = chrono::Local::now().format("%F-%H-%M-%S").to_string();
     log_name.push_str(".log");
     let config = ConfigBuilder::new()
         .set_time_offset_to_local()
         .unwrap()
         .build();
-    let log_path = config_dir_path.join("log");
+    let log_path = {
+        let mut path = data_local_path.to_path_buf();
+        path.push(FELIX);
+        path.push("log");
+        path
+    };
     if !log_path.exists() {
         std::fs::create_dir(&log_path)?;
     }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -71,7 +71,7 @@ pub fn rename_dir(dir_name: &str, name_set: &BTreeSet<String>) -> String {
 
 /// Move to information bar.
 pub fn go_to_and_rest_info() {
-    to_info_bar();
+    to_info_line();
     clear_current_line();
 }
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -72,18 +72,6 @@ pub fn rename_dir(dir_name: &str, name_set: &BTreeSet<String>) -> String {
     new_name
 }
 
-/// Move to information bar.
-pub fn go_to_and_rest_info() {
-    to_info_line();
-    clear_current_line();
-}
-
-/// Delele cursor.
-pub fn delete_cursor() {
-    print!(" ");
-    move_left(1);
-}
-
 /// Print the result of operation, such as put/delete/redo/undo.
 pub fn print_info<T: std::fmt::Display>(message: T, then: u16) {
     delete_cursor();

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -13,6 +13,9 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 pub const PROCESS_INDICATOR_LENGTH: u16 = 7;
+const KB: u64 = 1000;
+const MB: u64 = 1_000_000;
+const GB: u64 = 1_000_000_000;
 
 /// Generate modified time as `String`.
 pub fn format_time(time: &Option<String>) -> String {
@@ -160,17 +163,17 @@ pub fn duration_to_string(duration: Duration) -> String {
 /// Get the size format of item.
 pub fn to_proper_size(byte: u64) -> String {
     let mut result: String;
-    if byte < 1000 {
+    if byte < KB {
         result = byte.to_string();
         result.push('B');
-    } else if byte < 1_000_000 {
-        result = (byte / 1_000).to_string();
+    } else if byte < MB {
+        result = (byte / KB).to_string();
         result.push_str("KB");
-    } else if byte < 1_000_000_000 {
-        result = (byte / 1_000_000).to_string();
+    } else if byte < GB {
+        result = (byte / MB).to_string();
         result.push_str("MB");
     } else {
-        result = (byte / 1_000_000_000).to_string();
+        result = (byte / GB).to_string();
         result.push_str("GB");
     }
     result

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,5 +1,5 @@
 /// Help text.
-pub const HELP: &str = "# felix v2.1.1
+pub const HELP: &str = "# felix v2.2.0
 A simple TUI file manager with vim-like keymapping.
 
 ## Usage
@@ -46,6 +46,7 @@ Esc               :Return to the normal mode.
 :cd / :z          :Go to the home directory.
 :z <keyword>      :Same as `z <keyword>`.
 :e                :Reload the current directory.
+:trash            :Go to the trash directory.
 :empty            :Empty the trash directory.
 :h                :Show help.
 :q / ZZ           :Exit.

--- a/src/run.rs
+++ b/src/run.rs
@@ -34,26 +34,27 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
         path.push(FELIX);
         path
     };
+    let data_local_path = dirs::data_local_dir()
+        .ok_or_else(|| FxError::Dirs("Cannot read data local directory.".to_string()))?;
+
     let config_file_path = config_dir_path.join(PathBuf::from(CONFIG_FILE));
     let trash_dir_path = {
-        let mut path = dirs::data_local_dir()
-            .ok_or_else(|| FxError::Dirs("Cannot read data local directory.".to_string()))?;
+        let mut path = data_local_path.clone();
         path.push(FELIX);
         path.push(TRASH);
         path
     };
 
-    if log {
-        init_log(&config_dir_path)?;
-    }
-
     //Make config file and trash directory if not exists.
     make_config_if_not_exists(&config_file_path, &trash_dir_path)?;
 
+    if log {
+        init_log(&data_local_path)?;
+    }
+
     //If session file, which stores sortkey and whether to show hidden items, does not exist (i.e. first launch), make it.
     let session_file_path = {
-        let mut path = dirs::data_local_dir()
-            .ok_or_else(|| FxError::Dirs("Cannot read data local directory.".to_string()))?;
+        let mut path = data_local_path;
         path.push(FELIX);
         path.push(SESSION_FILE);
         path

--- a/src/run.rs
+++ b/src/run.rs
@@ -1266,11 +1266,12 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 state.reload(BEGINNING_ROW)?;
                                                 break 'command;
                                             } else if command == "h" {
+                                                //show help
                                                 state.show_help(&screen)?;
                                                 state.redraw(state.layout.y);
                                                 break 'command;
                                             } else if command == "trash" {
-                                                //Move to trash dir
+                                                //move to trash dir
                                                 state.layout.nums.reset();
                                                 if let Err(e) = state
                                                     .chdir(&(state.trash_dir.clone()), Move::Jump)
@@ -1279,6 +1280,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 }
                                                 break 'command;
                                             } else if command == "empty" {
+                                                //empty the trash dir
                                                 state.empty_trash(&screen)?;
                                                 break 'command;
                                             }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1429,6 +1429,16 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                             }
                                         }
 
+                                        if c == "trash" && args.is_empty() {
+                                            //Move to trash dir
+                                            state.layout.nums.reset();
+                                            if let Err(e) =
+                                                state.chdir(&(state.trash_dir.clone()), Move::Jump)
+                                            {
+                                                print_warning(e, state.layout.y);
+                                            }
+                                            break 'command;
+                                        }
                                         //Execute the command as it is
                                         execute!(screen, EnterAlternateScreen)?;
                                         if std::env::set_current_dir(&state.current_dir).is_err() {

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,7 +1,6 @@
 use super::config::{make_config_if_not_exists, CONFIG_FILE};
 use super::errors::FxError;
 use super::functions::*;
-use super::help::HELP;
 use super::layout::Split;
 use super::nums::*;
 use super::op::*;
@@ -191,8 +190,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
 
                     //Go to top
                     KeyCode::Char('g') => {
-                        to_info_line();
-                        clear_current_line();
+                        go_to_and_rest_info();
                         print!("g");
                         show_cursor();
                         screen.flush()?;
@@ -1369,7 +1367,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                     //undo
                     KeyCode::Char('u') => {
                         let op_len = state.operations.op_list.len();
-                        if op_len < state.operations.pos + 1 {
+                        if op_len <= state.operations.pos {
                             print_info("No operations left.", state.layout.y);
                             continue;
                         }
@@ -1431,18 +1429,10 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                         }
                     }
 
-                    //Debug print for undo/redo
-                    KeyCode::Char('P') => {
-                        if state.rust_log.is_some() {
-                            print_info(format!("{:?}", state), state.layout.y);
-                        }
-                    }
-
                     //exit by ZZ
                     KeyCode::Char('Z') => {
                         delete_cursor();
-                        to_info_line();
-                        clear_current_line();
+                        go_to_and_rest_info();
                         print!("Z");
                         show_cursor();
                         screen.flush()?;
@@ -1462,7 +1452,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                         }
                     }
 
-                    //If input does not match any of the keys up to this point, ignore it
+                    //If input does not match any of the defined keys, ignore it.
                     _ => {
                         continue;
                     }
@@ -1529,7 +1519,7 @@ mod tests {
     #[test]
     fn zoxide_test() {
         let output = std::process::Command::new("zoxide")
-            .args(["query", "dotfiles"])
+            .args(["query", "felix"])
             .output()
             .unwrap();
         let stdout = std::str::from_utf8(&output.stdout).unwrap().trim();

--- a/src/run.rs
+++ b/src/run.rs
@@ -236,10 +236,6 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                     }
                                     execute!(screen, EnterAlternateScreen)?;
                                     hide_cursor();
-                                    //Add thread sleep time after state.open_file().
-                                    // This is necessary because, with tiling window managers, the window resizing is sometimes slow and felix reloads the layout so quickly that the display may become broken.
-                                    //By the sleep (50ms for now and I think it's not easy to recognize this sleep), this will be avoided.
-                                    std::thread::sleep(Duration::from_millis(50));
                                     state.reload(state.layout.y)?;
                                     continue;
                                 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,5 @@
 use super::errors::FxError;
 use super::layout::Split;
-use super::state::FX_CONFIG_DIR;
 use serde::{Deserialize, Serialize};
 use std::fs::read_to_string;
 use std::path::Path;
@@ -26,14 +25,17 @@ pub enum SortKey {
     Time,
 }
 
-pub fn read_session() -> Result<Session, FxError> {
-    let mut session =
-        dirs::config_dir().ok_or_else(|| FxError::Dirs("Cannot read config dir.".to_string()))?;
-    session.push(FX_CONFIG_DIR);
-    session.push(SESSION_FILE);
-    let session = read_to_string(session.as_path())?;
-    match serde_yaml::from_str(&session) {
-        Ok(de) => Ok(de),
+pub fn read_session(session_path: &Path) -> Result<Session, FxError> {
+    match read_to_string(session_path) {
+        Ok(s) => match serde_yaml::from_str(&s) {
+            Ok(de) => Ok(de),
+            Err(_) => Ok(Session {
+                sort_by: SortKey::Name,
+                show_hidden: true,
+                preview: Some(false),
+                split: Some(Split::Vertical),
+            }),
+        },
         Err(_) => Ok(Session {
             sort_by: SortKey::Name,
             show_hidden: true,

--- a/src/state.rs
+++ b/src/state.rs
@@ -348,8 +348,8 @@ impl State {
         let mut to = PathBuf::new();
 
         if item.file_type == FileType::Symlink && !from.exists() {
-            match Command::new("rm").arg(from).status() {
-                Ok(_) => Ok(PathBuf::new()),
+            match std::fs::remove_file(from) {
+                Ok(_) => Ok(None),
                 Err(_) => Err(FxError::RemoveItem(from.to_owned())),
             }
         } else {

--- a/src/state.rs
+++ b/src/state.rs
@@ -306,8 +306,8 @@ impl State {
         for (i, item) in targets.iter().enumerate() {
             let item = item.clone();
 
-            print!(" ");
-            to_info_bar();
+            delete_cursor();
+            to_info_line();
             clear_current_line();
             print!("{}", display_count(i, total_selected));
 
@@ -519,8 +519,8 @@ impl State {
 
         let total_selected = targets.len();
         for (i, item) in targets.iter().enumerate() {
-            print!(" ");
-            to_info_bar();
+            delete_cursor();
+            to_info_line();
             clear_current_line();
             print!("{}", display_count(i, total_selected));
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,9 +26,8 @@ use syntect::highlighting::{Theme, ThemeSet};
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
 
+pub const FELIX: &str = "felix";
 pub const BEGINNING_ROW: u16 = 3;
-pub const FX_CONFIG_DIR: &str = "felix";
-pub const TRASH: &str = "trash";
 pub const EMPTY_WARNING: &str = "Are you sure to empty the trash directory? (if yes: y)";
 const TIME_PREFIX: usize = 11;
 
@@ -81,7 +80,7 @@ impl Default for FileType {
 
 impl State {
     /// Initialize the state of the app.
-    pub fn new(p: &std::path::Path) -> Result<Self, FxError> {
+    pub fn new(p: &std::path::Path, session_path: &std::path::Path) -> Result<Self, FxError> {
         let config = match read_config(p) {
             Ok(c) => c,
             Err(e) => {
@@ -105,7 +104,7 @@ impl State {
                 Config::default()
             }
         };
-        let session = read_session()?;
+        let session = read_session(session_path)?;
         let (original_column, original_row) = terminal_size()?;
 
         // Return error if terminal size may cause panic

--- a/src/term.rs
+++ b/src/term.rs
@@ -36,7 +36,7 @@ pub fn move_to(x: u16, y: u16) {
     print!("{}", MoveTo(x - 1, y - 1));
 }
 
-pub fn to_info_bar() {
+pub fn to_info_line() {
     move_to(2, 2);
 }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -44,6 +44,11 @@ pub fn clear_current_line() {
     print!("{}", Clear(crossterm::terminal::ClearType::CurrentLine));
 }
 
+pub fn go_to_and_rest_info() {
+    to_info_line();
+    clear_current_line();
+}
+
 pub fn clear_until_newline() {
     print!("{}", Clear(crossterm::terminal::ClearType::UntilNewLine));
 }
@@ -70,6 +75,11 @@ pub fn show_cursor() {
 
 pub fn print_pointer() {
     print!(">");
+}
+
+pub fn delete_cursor() {
+    print!(" ");
+    move_left(1);
 }
 
 pub fn set_color(c: &TermColor) {


### PR DESCRIPTION
## v2.2.0 (2022-12-10)

### Changed

- IMPORTANT: Trash and log directory path changed: from v2.2.0, felix will use `data_local_dir()` to store the deleted items and log files, instead of `config_dir()`. Due to this change, the path for linux will be `$XDG_DATA_HOME/felix/{Trash, log}`, in most case `/home/user/.local/share/felix/{Trash, log}`. For Windows `{FOLDERID_LocalAppData}\felix\{Trash, log}`, in most case `C:\Users\user\AppData\Local\felix\{Trash, log}`. No change for macOS users. Note that config file path is not changed.

### Added

- `:trash` to go to the trash directory.

### Fixed

- Support NetBSD to open file in a new window.
- Properly remove broken symlink in Windows as well. Also, when deleting/puttiing a directory, broken symlink(s) inside it won't cause any error and remove from the file system after deleting/putting.
