### PR TITLE
Update README.md about installation on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ rustup update
 cargo install felix
 ```
 
-### From AUR
+### Arch Linux
 
 ```
-yay -S felix-rs
+pacman -S felix-rs
 ```
 
 ### NetBSD


### PR DESCRIPTION
`felix-rs` is moved to the community repository: https://archlinux.org/packages/community/x86_64/felix-rs/
