### PR TITLE
v2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+## v2.2.4 (2023-02-01)
+
 ### Fixed
 - Disable remove_and_yank in the trash dir.
 - Clear selection in the select mode if something fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - Disable remove_and_yank in the trash dir.
 - Clear selection in the select mode if something fails.
+- Cursor move after deleting multiple items in select mode.
 
 ## v2.2.3 (2023-01-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Fixed
+- Disable remove_and_yank in the trash dir.
+- Clear selection in the select mode if something fails.
+
 ## v2.2.3 (2023-01-20)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "felix"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "chrono",
  "content_inspector",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felix"
-version = "2.2.3"
+version = "2.2.4"
 authors = ["Kyohei Uto <im@kyoheiu.dev>"]
 edition = "2021"
 description = "tui file manager with vim-like key mapping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/kyoheiu/felix"
 license = "MIT"
 keywords = ["tui", "crossterm", "file-manager"]
 categories = ["command-line-utilities", "filesystem"]
+exclude = [
+    "testfiles/*"
+]
 
 [[bin]]
 name = "fx"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ For more detailed document, visit https://kyoheiu.dev/felix.
 
 ## New release
 
+## v2.2.4 (2023-02-01)
+
+### Fixed
+- Disable remove_and_yank in the trash dir.
+- Clear selection in the select mode if something fails.
+- Cursor move after deleting multiple items in select mode.
+
 ## v2.2.3 (2023-01-20)
 
 ### Fixed
@@ -32,14 +39,6 @@ For more detailed document, visit https://kyoheiu.dev/felix.
 ### Added
 - `chafa`'s minimal supported version: >= v1.10.0
 - Add pacman installation.
-
-## v2.2.2 (2022-12-19)
-
-### Fixed
-
-- Disable commands with Ctrl or other modifiers unless explicitly implemented. (For now, `Ctrl + r` to redo, `Alt + j` and `Alt + k` to scroll the preview text are implemented) This avoids for example the situation where `Ctrl + d` unintentionally deletes an item.
-- Add `create_dir_all` to `config_dir` and `data_local_dir` to avoid error.
-- Check if the argument is directory.
 
 For more details, see `CHANGELOG.md`.
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,5 +1,5 @@
 /// Help text.
-pub const HELP: &str = "# felix v2.2.3
+pub const HELP: &str = "# felix v2.2.4
 A simple TUI file manager with vim-like keymapping.
 
 ## Usage

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -246,7 +246,11 @@ impl Layout {
                 format!("--size={}x{}", self.preview_space.0, self.preview_space.1)
             }
             Split::Horizontal => {
-                format!("--size={}x{}", self.preview_space.0, self.preview_space.1)
+                format!(
+                    "--size={}x{}",
+                    self.preview_space.0,
+                    self.preview_space.1 - 1
+                )
             }
         };
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -713,6 +713,8 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 if let Err(e) =
                                                     state.remove_and_yank(&selected, true)
                                                 {
+                                                    state.reset_selection();
+                                                    state.redraw(state.layout.y);
                                                     print_warning(e, state.layout.y);
                                                     break;
                                                 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -721,11 +721,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
 
                                                 state.update_list()?;
                                                 let new_len = state.list.len();
-                                                if usize::from(state.layout.nums.skip) >= new_len {
-                                                    state.layout.nums.reset();
-                                                }
                                                 state.clear_and_show_headline();
-                                                state.list_up();
 
                                                 let duration = duration_to_string(start.elapsed());
                                                 let delete_message: String = {
@@ -746,20 +742,30 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
 
                                                 if new_len == 0 {
                                                     state.layout.nums.reset();
+                                                    state.list_up();
                                                     state.move_cursor(BEGINNING_ROW);
-                                                } else if state.layout.nums.index > new_len - 1 {
-                                                    let mut new_y = state.layout.y
-                                                        - (state.layout.nums.index - (new_len - 1))
-                                                            as u16;
-                                                    if new_y < BEGINNING_ROW {
-                                                        new_y = BEGINNING_ROW;
+                                                } else if state.is_out_of_bounds() {
+                                                    if state.layout.nums.skip as usize >= new_len {
+                                                        state.layout.nums.skip =
+                                                            (new_len - 1) as u16;
+                                                        state.layout.nums.index =
+                                                            state.list.len() - 1;
+                                                        state.list_up();
+                                                        state.move_cursor(BEGINNING_ROW);
+                                                    } else {
+                                                        state.layout.nums.index =
+                                                            state.list.len() - 1;
+                                                        state.list_up();
+                                                        state.move_cursor(
+                                                            (state.list.len() as u16)
+                                                                - state.layout.nums.skip
+                                                                + BEGINNING_ROW
+                                                                - 1,
+                                                        );
                                                     }
-                                                    state.layout.nums.index = new_len - 1;
-                                                    state.move_cursor(new_y);
-                                                    screen.flush()?;
                                                 } else {
+                                                    state.list_up();
                                                     state.move_cursor(state.layout.y);
-                                                    screen.flush()?;
                                                 }
                                                 break;
                                             }

--- a/src/state.rs
+++ b/src/state.rs
@@ -300,6 +300,12 @@ impl State {
     /// This does not actually delete items.
     /// If you'd like to delete, use `:empty` after this, or just `:rm`.  
     pub fn remove_and_yank(&mut self, targets: &[ItemInfo], new_op: bool) -> Result<(), FxError> {
+        if self.current_dir == self.trash_dir {
+            return Err(FxError::Io(
+                "Use `:empty` to delete item in the trash dir.".to_string(),
+            ));
+        }
+
         self.registered.clear();
         let total_selected = targets.len();
         let mut trash_vec = Vec::new();

--- a/src/state.rs
+++ b/src/state.rs
@@ -1392,6 +1392,11 @@ impl State {
         magic_packed::unpack(&p, &dest)?;
         Ok(())
     }
+
+    pub fn is_out_of_bounds(&self) -> bool {
+        let current = self.layout.nums.skip + self.layout.y - BEGINNING_ROW + 1;
+        current as usize > self.list.len()
+    }
 }
 
 /// Read item information from `std::fs::DirEntry`.

--- a/src/state.rs
+++ b/src/state.rs
@@ -767,7 +767,7 @@ impl State {
         self.layout.terminal_column = column;
         self.layout.preview_start = match self.layout.split {
             Split::Vertical => (column + 2, BEGINNING_ROW),
-            Split::Horizontal => (1, row + 1),
+            Split::Horizontal => (1, row + 2),
         };
         self.layout.preview_space = match self.layout.preview {
             true => match self.layout.split {


### PR DESCRIPTION
### Fixed
- Disable remove_and_yank in the trash dir.
- Clear selection in the select mode if something fails.
- Cursor move after deleting multiple items in select mode.