### PR TITLE
Fix the write permission test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "exacl"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfeb22a59deb24c3262c43ffcafd1eb807180f371f9fcc99098d181b5d639be"
+dependencies = [
+ "bitflags",
+ "log",
+ "scopeguard",
+ "uuid",
+]
+
+[[package]]
 name = "felix"
 version = "2.2.7"
 dependencies = [
@@ -378,6 +390,7 @@ dependencies = [
  "crossterm",
  "devtimer",
  "dirs",
+ "exacl",
  "flate2",
  "log",
  "lzma-rs",
@@ -1152,6 +1165,12 @@ name = "unsafe-libyaml"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+
+[[package]]
+name = "uuid"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ unicode-width = "0.1.10"
 
 [dev-dependencies]
 devtimer = "4.0.0"
+exacl = "0.10.0"
 rayon = "1.6.1"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/state.rs
+++ b/src/state.rs
@@ -1762,9 +1762,9 @@ mod tests {
         assert!(!has_write_permission(p.as_path()).unwrap());
         // Reset the permission
         let entries = vec![
-            AclEntry::allow_user("", Perm::READ | Perm::WRITE, None),
-            AclEntry::allow_group("", Perm::READ | Perm::WRITE, None),
-            AclEntry::allow_other(Perm::READ | Perm::WRITE, None),
+            AclEntry::allow_user("", Perm::READ | Perm::WRITE | Perm::EXECUTE, None),
+            AclEntry::allow_group("", Perm::READ | Perm::EXECUTE, None),
+            AclEntry::allow_other(Perm::READ | Perm::EXECUTE, None),
         ];
         setfacl(&[p], &entries, None).unwrap();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,13 +26,13 @@ use std::time::UNIX_EPOCH;
 use syntect::highlighting::{Theme, ThemeSet};
 
 #[cfg(target_family = "unix")]
-use std::os::unix::fs::PermissionsExt;
-#[cfg(target_family = "unix")]
-use std::os::unix::fs::MetadataExt;
-#[cfg(target_family = "unix")]
 use nix::sys::stat::Mode;
 #[cfg(target_family = "unix")]
 use nix::unistd::{Gid, Uid};
+#[cfg(target_family = "unix")]
+use std::os::unix::fs::MetadataExt;
+#[cfg(target_family = "unix")]
+use std::os::unix::fs::PermissionsExt;
 
 pub const FELIX: &str = "felix";
 pub const BEGINNING_ROW: u16 = 3;

--- a/testfiles/permission_test/empty.txt
+++ b/testfiles/permission_test/empty.txt
@@ -1,0 +1,1 @@
+Empty file.


### PR DESCRIPTION
Use `exacl` to temporarily change the perm of the test file