### PR TITLE
v2.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+## v2.2.8 (2023-05-19)
+
+### Fixed
+
+- Kitty-specific: Enable scrolling of the preview text by redrawing the screen only when needed (this also improves the perfomance entirely).
+
 ## v2.2.7 (2023-05-05)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "felix"
-version = "2.2.7"
+version = "2.2.8"
 dependencies = [
  "chrono",
  "content_inspector",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felix"
-version = "2.2.7"
+version = "2.2.8"
 authors = ["Kyohei Uto <im@kyoheiu.dev>"]
 edition = "2021"
 description = "tui file manager with vim-like key mapping"

--- a/README.md
+++ b/README.md
@@ -26,21 +26,17 @@ For more detailed document, visit https://kyoheiu.dev/felix.
 
 ## New release
 
+## v2.2.8 (2023-05-19)
+
+### Fixed
+
+- Kitty-specific: Enable scrolling of the preview text by redrawing the screen only when needed (this also improves the perfomance entirely).
+
 ## v2.2.7 (2023-05-05)
 
 ### Added
 
 - Print `[RO]` on the headline if user does not have the write permission on the directory. This is available only on UNIX for now.
-
-
-## v2.2.6 (2023-04-24)
-
-### Removed
-
-- Remove duplicated `-v | --version` option. This is because i) Since some users
-  do not have `cargo` installed, fetching latest version via `cargo` doesn't
-  work for many, and ii) `-h | --help` option can already show the current
-  version.
 
 For more details, see `CHANGELOG.md`.
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,5 +1,5 @@
 /// Help text.
-pub const HELP: &str = "# felix v2.2.7
+pub const HELP: &str = "# felix v2.2.8
 A simple TUI file manager with vim-like keymapping.
 
 ## Usage

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,7 +1,8 @@
+
 use super::config::{make_config_if_not_exists, CONFIG_FILE};
 use super::errors::FxError;
 use super::functions::*;
-use super::layout::Split;
+use super::layout::{Split, PreviewType};
 use super::nums::*;
 use super::op::*;
 use super::session::*;
@@ -1630,7 +1631,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                 //If you use kitty, you must clear the screen by the escape sequence or the previewed image remains.
                 if state.layout.is_kitty && state.layout.preview {
                     if let Ok(item) = state.get_item() {
-                        if item.preview_scroll == 0 {
+                        if item.preview_type == Some(PreviewType::Image) {
                             print!("{}", CLRSCR);
                             state.clear_and_show_headline();
                             state.list_up();


### PR DESCRIPTION
## v2.2.8 (2023-05-19)

### Fixed

- Kitty-specific: Enable scrolling of the preview text by redrawing the screen only when needed (this also improves the perfomance entirely).