### PR TITLE
v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 ### Changed
 
-- Add config file path for macOS: `/Users/$USER/.config/felix/config.yaml` will be read after `$HOME/Library/Application Support/felix/config.yaml`.
-- If config file is not found or broken, felix launches with the default configuration, without creating any file.
+- Add extra config file path for macOS: `/Users/$USER/.config/felix/config.yaml` will be read after `$HOME/Library/Application Support/felix/config.yaml`.
+- If config file is not found, or found one is broken, felix launches with the default configuration, without creating new one.
 - If the current directory is read-only, `dd`, `Vd` and `p` is disabled in the first place.
 - Bump up MSRV to 1.65.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,22 @@
 
 ## Unreleased
 
+### Added
+
+- Create temp file or directory by `af` or `ad` respectively. This feature has to feel like more "modal", so for now I comment out this feature.
+
+## v2.3.0 (2023-05-26)
+
 ### Changed
 
 - Add config file path for macOS: `/Users/$USER/.config/felix/config.yaml` will be read after `$HOME/Library/Application Support/felix/config.yaml`.
 - If config file is not found or broken, felix launches with the default configuration, without creating any file.
-- If the current directory is read-only, deleting and putting is disabled.
+- If the current directory is read-only, `dd`, `Vd` and `p` is disabled in the first place.
+- Bump up MSRV to 1.65.
 
 ### Added
 
-- Create temp file or directory by `af` or `ad` respectively. This feature has to feel more "modal", so for now I comment out this feature.
+- Add `is_ro` field to `State`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+### Changed
+
+- Add config file path for macOS: `/Users/$USER/.config/felix/config.yaml` will be read after `$HOME/Library/Application Support/felix/config.yaml`.
+- If config file is not found or broken, felix launches with the default configuration, without creating any file.
+- If the current directory is read-only, deleting and putting is disabled.
+
 ### Added
 
 - Create temp file or directory by `af` or `ad` respectively. This feature has to feel more "modal", so for now I comment out this feature.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "felix"
-version = "2.2.8"
+version = "2.3.0"
 dependencies = [
  "chrono",
  "content_inspector",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,14 +10,13 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug",
 ]
 
 [[package]]
@@ -37,15 +36,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bincode"
@@ -64,9 +63,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -79,9 +78,9 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -91,9 +90,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bzip2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -112,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -139,21 +138,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -173,15 +163,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -206,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -216,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -227,22 +217,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -283,50 +273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 1.0.105",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.105",
-]
-
-[[package]]
 name = "devtimer"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,9 +280,9 @@ checksum = "907339959a92f6b98846570500c0a567c9aecbb3871cef00561eb5d20d47b7c1"
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -365,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "felix"
@@ -397,14 +343,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -425,9 +371,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -435,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -470,67 +416,75 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.4"
+name = "inout"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "line-wrap"
@@ -539,15 +493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
 dependencies = [
  "safemem",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -602,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -620,14 +565,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -690,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "onig"
@@ -717,12 +662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,15 +673,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -776,38 +715,47 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plist"
-version = "1.3.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+checksum = "9bd9647b268a3d3e14ff09c23201133a62589c658db02bb7388c7246aafe0590"
 dependencies = [
  "base64",
  "indexmap",
  "line-wrap",
+ "quick-xml",
  "serde",
  "time",
- "xml-rs",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.26"
+name = "quick-xml"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -820,9 +768,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -830,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -862,15 +810,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safemem"
@@ -894,36 +842,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
-
-[[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -932,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.14"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
  "indexmap",
  "itoa",
@@ -967,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -988,18 +930,18 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "simplelog"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
+checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
 dependencies = [
  "log",
  "termcolor",
@@ -1014,26 +956,15 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1043,7 +974,7 @@ dependencies = [
 [[package]]
 name = "syntect"
 version = "5.0.0"
-source = "git+https://github.com/kyoheiu/syntect#b2dc4fb8ee192f27babb0535eb383b781ab5c8ce"
+source = "git+https://github.com/kyoheiu/syntect#b5212417475f678706bdc243d7adbf99b26923bd"
 dependencies = [
  "bincode",
  "bitflags",
@@ -1082,29 +1013,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.105",
+ "syn",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "libc",
@@ -1116,15 +1047,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -1137,9 +1068,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-width"
@@ -1149,9 +1080,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.4"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "version_check"
@@ -1177,9 +1108,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1187,24 +1118,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.105",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1212,22 +1143,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.105",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "winapi"
@@ -1261,61 +1192,145 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.42.0"
+name = "windows"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "xattr"
@@ -1325,12 +1340,6 @@ checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "yaml-rust"
@@ -1343,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
  "aes",
  "byteorder",
@@ -1382,10 +1391,11 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.4+zstd.1.5.2"
+version = "2.0.8+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felix"
-version = "2.2.8"
+version = "2.3.0"
 authors = ["Kyohei Uto <im@kyoheiu.dev>"]
 edition = "2021"
 description = "tui file manager with vim-like key mapping"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![crates.io](https://img.shields.io/crates/v/felix)](https://crates.io/crates/felix)
-![arch linux](https://img.shields.io/archlinux/v/community/x86_64/felix-rs)
+![arch linux](https://img.shields.io/archlinux/v/extra/x86_64/felix-rs)
 ![MSRV](https://img.shields.io/badge/MSRV-1.60.0-orange)
 
 # _felix_

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For more detailed document, visit https://kyoheiu.dev/felix.
 
 ### Changed
 
-- Add config file path for macOS: `/Users/$USER/.config/felix/config.yaml` will be read after `$HOME/Library/Application Support/felix/config.yaml`.
-- If config file is not found or broken, felix launches with the default configuration, without creating any file.
+- Add extra config file path for macOS: `/Users/$USER/.config/felix/config.yaml` will be read after `$HOME/Library/Application Support/felix/config.yaml`.
+- If config file is not found, or found one is broken, felix launches with the default configuration, without creating new one.
 - If the current directory is read-only, `dd`, `Vd` and `p` is disabled in the first place.
 - Bump up MSRV to 1.65.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![crates.io](https://img.shields.io/crates/v/felix)](https://crates.io/crates/felix)
 ![arch linux](https://img.shields.io/archlinux/v/extra/x86_64/felix-rs)
-![MSRV](https://img.shields.io/badge/MSRV-1.60.0-orange)
+![MSRV](https://img.shields.io/badge/MSRV-1.65.0-orange)
 
 # _felix_
 
@@ -26,17 +26,20 @@ For more detailed document, visit https://kyoheiu.dev/felix.
 
 ## New release
 
+## v2.3.0 (2023-05-26)
+
+### Changed
+
+- Add config file path for macOS: `/Users/$USER/.config/felix/config.yaml` will be read after `$HOME/Library/Application Support/felix/config.yaml`.
+- If config file is not found or broken, felix launches with the default configuration, without creating any file.
+- If the current directory is read-only, `dd`, `Vd` and `p` is disabled in the first place.
+- Bump up MSRV to 1.65.
+
 ## v2.2.8 (2023-05-19)
 
 ### Fixed
 
 - Kitty-specific: Enable scrolling of the preview text by redrawing the screen only when needed (this also improves the perfomance entirely).
-
-## v2.2.7 (2023-05-05)
-
-### Added
-
-- Print `[RO]` on the headline if user does not have the write permission on the directory. This is available only on UNIX for now.
 
 For more details, see `CHANGELOG.md`.
 
@@ -61,16 +64,16 @@ report any problems._
 
 | package    | installation command  | notes                                                                                                                                       |
 | ---------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| crates.io  | `cargo install felix` | Minimal supported rustc version: **1.60.0**                                                                                                 |
+| crates.io  | `cargo install felix` | Minimum Supported rustc Version: **1.65.0**                                                                                                 |
 | Arch Linux | `pacman -S felix-rs`  | The binary name is `felix` if you install via pacman. Alias `fx='felix'` if you want, as this document (and other installations) uses `fx`. |
 | NetBSD     | `pkgin install felix` |                                                                                                                                             |
 
 ### From this repository
 
 - Make sure that `gcc` is installed.
-- MSRV(Minimum Supported rustc Version): **1.60.0**
+- MSRV(Minimum Supported rustc Version): **1.65.0**
 
-Update Rust if rustc < 1.60:
+Update Rust if rustc < 1.65:
 
 ```
 rustup update
@@ -124,12 +127,12 @@ j / Down          :Go down.
 k / Up            :Go up.
 h / Left          :Go to the parent directory if exists.
 l / Right / Enter :Open a file or change directory.
-o                 :Open a file in a new window.
-e                 :Unpack archive/compressed file.
 gg                :Go to the top.
 G                 :Go to the bottom.
 z + Enter         :Go to the home directory.
 z <keyword>       :Jump to a directory that matches the keyword. (zoxide required)
+o                 :Open a file in a new window.
+e                 :Unpack archive/compressed file.
 dd                :Delete and yank one item.
 yy                :Yank one item.
 p                 :Put yanked item(s) in the current directory.
@@ -146,7 +149,7 @@ backspace         :Toggle whether to show hidden items.
 t                 :Toggle the sort order (name <-> modified time).
 :                 :Switch to the shell mode.
 c                 :Switch to the rename mode.
-/                 :Search items by the keyword.
+/                 :Search items by a keyword.
 n                 :Go forward to the item that matches the keyword.
 N                 :Go backward to the item that matches the keyword.
 Esc               :Return to the normal mode.
@@ -170,6 +173,14 @@ Install `chafa` and you can preview images without any configuration.
 
 ## Configuration
 
+### Config file
+If any config file is not found, or found one is broken, felix launches with the default configuration, without creating new one.
+Note that the default editor is `$EDITOR`, so if you've not set it, opening a file will fail.
+You can find default config file (`config.yaml`) in this repository.
+
+### Trash directory and log file
+Contrary to the config file, these directory and file will be automatically created.
+
 ### Linux
 
 ```
@@ -180,8 +191,12 @@ log files       : $XDG_DATA_HOME/felix/log
 
 ### macOS
 
+On macOS, felix looks for the config file in the following locations:
+
+1. `$HOME/Library/Application Support/felix/config.yaml`
+2. `$HOME/.config/felix/config.yaml`
+
 ```
-config file     : $HOME/Library/Application Support/felix/config.yaml
 trash directory : $HOME/Library/Application Support/felix/Trash
 log files       : $HOME/Library/Application Support/felix/log
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,7 +167,7 @@ pub fn read_or_create_config() -> Result<Config, FxError> {
     //On macOS, felix looks for 2 paths:
     //First `$HOME/Library/Application Support/felix/config.yaml`,
     //and if it fails,
-    //`~/.config/felix/config.yaml`.
+    //`$HOME/.config/felix/config.yaml`.
     let config_file_paths = if cfg!(macos) {
         let alt_config_file_path = {
             let mut path = dirs::home_dir()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,14 +1,16 @@
-use super::errors::FxError;
-use super::state::FELIX;
+use crate::errors::FxError;
 
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
-pub const CONFIG_FILE: &str = "config.yaml";
+pub const FELIX: &str = "felix";
+const CONFIG_FILE: &str = "config.yaml";
 
-pub const CONFIG_EXAMPLE: &str = "# (Optional)
+#[allow(dead_code)]
+const CONFIG_EXAMPLE: &str = r###"
+# (Optional)
 # Default exec command when open files.
 # If not set, will default to $EDITOR.
 # default: nvim
@@ -70,7 +72,7 @@ color:
   dir_fg: LightCyan
   file_fg: LightWhite
   symlink_fg: LightYellow
-";
+"###;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {
@@ -139,88 +141,63 @@ impl Default for Config {
     }
 }
 
-pub fn read_config(p: &Path) -> Result<Config, FxError> {
+fn read_config(p: &Path) -> Result<Config, FxError> {
     let s = read_to_string(p)?;
     read_config_from_str(&s)
 }
 
-pub fn read_config_from_str(s: &str) -> Result<Config, FxError> {
+fn read_config_from_str(s: &str) -> Result<Config, FxError> {
     let deserialized: Config = serde_yaml::from_str(s)?;
     Ok(deserialized)
 }
 
-pub fn read_or_create_config(config_paths: &Vec<PathBuf>) -> Result<Config, FxError> {
+pub fn read_or_create_config() -> Result<Config, FxError> {
+    //First, declare default config file path.
+    let config_file_path = {
+        let config_dir_path = {
+            let mut path = dirs::config_dir()
+                .ok_or_else(|| FxError::Dirs("Cannot read the config directory.".to_string()))?;
+            path.push(FELIX);
+            path
+        };
+        if !config_dir_path.exists() {
+            std::fs::create_dir_all(&config_dir_path)?;
+        }
+
+        let mut path = config_dir_path;
+        path.push(CONFIG_FILE);
+        path
+    };
+
+    //On macOS, felix looks for 2 paths:
+    //$HOME/Library/Application Support/felix/config.yaml,
+    //and if it fails,
+    //~/.config/felix/config.yaml.
+    let config_file_paths = if cfg!(macos) {
+        let alt_config_file_path = {
+            let mut path = dirs::home_dir()
+                .ok_or_else(|| FxError::Dirs("Cannot read the home directory.".to_string()))?;
+            path.push(".config");
+            path.push("FELIX");
+            path.push(CONFIG_FILE);
+            path
+        };
+        vec![config_file_path, alt_config_file_path]
+    } else {
+        vec![config_file_path]
+    };
+
     let mut config_file: Option<PathBuf> = None;
-    for p in config_paths {
+    for p in config_file_paths {
         if p.exists() {
             config_file = Some(p.to_path_buf());
         }
     }
 
-    if config_file.is_some() {
-        read_config(&config_file.unwrap())
+    if let Some(config_file) = config_file {
+        read_config(&config_file)
     } else {
-        println!(
-            "Config file not found: To set up, please enter the default command name to open a file. (e.g. nvim)\nIf you want to use the default $EDITOR, just press Enter."
-        );
-
-        let mut buffer = String::new();
-        let stdin = std::io::stdin();
-        stdin.read_line(&mut buffer)?;
-
-        let mut trimmed = buffer.trim();
-        if trimmed.is_empty() {
-            match std::env::var("EDITOR") {
-                Ok(_) => {
-                    let config = CONFIG_EXAMPLE.replace("default = \"nvim\"", "# default = \"\"");
-                    std::fs::write(&config_paths[0], config.clone())?;
-                    println!("Config file created. See {}", config_file_path_output()?);
-                    read_config_from_str(&config)
-                }
-                Err(_) => {
-                    while trimmed.is_empty() {
-                        println!("Cannot detect $EDITOR: Enter your default command.");
-                        buffer = String::new();
-                        std::io::stdin().read_line(&mut buffer)?;
-                        trimmed = buffer.trim();
-                    }
-                    let config =
-                        CONFIG_EXAMPLE.replace("# default: nvim", &format!("default: {}", trimmed));
-                    std::fs::write(&config_paths[0], config.clone())?;
-                    println!(
-                        "Default command set as [{}]. See {}",
-                        trimmed,
-                        config_file_path_output()?
-                    );
-                    read_config_from_str(&config)
-                }
-            }
-        } else {
-            let config =
-                CONFIG_EXAMPLE.replace("# default: nvim", &format!("default: {}", trimmed));
-            std::fs::write(&config_paths[0], config.clone())?;
-            println!(
-                "Default command set as [{}]. See {}",
-                trimmed,
-                config_file_path_output()?
-            );
-            read_config_from_str(&config)
-        }
-    }
-}
-
-fn config_file_path() -> Result<PathBuf, FxError> {
-    let mut config =
-        dirs::config_dir().ok_or_else(|| FxError::Dirs("Cannot read config dir.".to_string()))?;
-    config.push(FELIX);
-    config.push(CONFIG_FILE);
-    Ok(config)
-}
-
-fn config_file_path_output() -> Result<String, FxError> {
-    if cfg!(target_os = "windows") {
-        Ok("~\\AppData\\Roaming\\felix\\config.yaml".to_owned())
-    } else {
-        Ok(config_file_path()?.to_str().unwrap().to_owned())
+        println!("Config file not found: felix launches with default configuration.");
+        Ok(Config::default())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,19 +154,14 @@ fn read_config_from_str(s: &str) -> Result<Config, FxError> {
 pub fn read_or_create_config() -> Result<Config, FxError> {
     //First, declare default config file path.
     let config_file_path = {
-        let config_dir_path = {
+        let mut config_path = {
             let mut path = dirs::config_dir()
                 .ok_or_else(|| FxError::Dirs("Cannot read the config directory.".to_string()))?;
             path.push(FELIX);
             path
         };
-        if !config_dir_path.exists() {
-            std::fs::create_dir_all(&config_dir_path)?;
-        }
-
-        let mut path = config_dir_path;
-        path.push(CONFIG_FILE);
-        path
+        config_path.push(CONFIG_FILE);
+        config_path
     };
 
     //On macOS, felix looks for 2 paths:
@@ -190,7 +185,8 @@ pub fn read_or_create_config() -> Result<Config, FxError> {
     let mut config_file: Option<PathBuf> = None;
     for p in config_file_paths {
         if p.exists() {
-            config_file = Some(p.to_path_buf());
+            config_file = Some(p);
+            break;
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,9 +165,9 @@ pub fn read_or_create_config() -> Result<Config, FxError> {
     };
 
     //On macOS, felix looks for 2 paths:
-    //$HOME/Library/Application Support/felix/config.yaml,
+    //First `$HOME/Library/Application Support/felix/config.yaml`,
     //and if it fails,
-    //~/.config/felix/config.yaml.
+    //`~/.config/felix/config.yaml`.
     let config_file_paths = if cfg!(macos) {
         let alt_config_file_path = {
             let mut path = dirs::home_dir()

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,7 +168,7 @@ pub fn read_or_create_config() -> Result<Config, FxError> {
     //First `$HOME/Library/Application Support/felix/config.yaml`,
     //and if it fails,
     //`$HOME/.config/felix/config.yaml`.
-    let config_file_paths = if cfg!(macos) {
+    let config_file_paths = if cfg!(target_os = "macos") {
         let alt_config_file_path = {
             let mut path = dirs::home_dir()
                 .ok_or_else(|| FxError::Dirs("Cannot read the home directory.".to_string()))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,7 +151,7 @@ fn read_config_from_str(s: &str) -> Result<Config, FxError> {
     Ok(deserialized)
 }
 
-pub fn read_or_create_config() -> Result<Config, FxError> {
+pub fn read_config_or_default() -> Result<Config, FxError> {
     //First, declare default config file path.
     let config_file_path = {
         let mut config_path = {

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,5 +1,5 @@
 /// Help text.
-pub const HELP: &str = "# felix v2.2.8
+pub const HELP: &str = "# felix v2.3.0
 A simple TUI file manager with vim-like keymapping.
 
 ## Usage
@@ -16,12 +16,12 @@ j / Down          :Go down.
 k / Up            :Go up.
 h / Left          :Go to the parent directory if exists.
 l / Right / Enter :Open a file or change directory.
-o                 :Open a file in a new window.
-e                 :Unpack archive/compressed file.
 gg                :Go to the top.
 G                 :Go to the bottom.
 z + Enter         :Go to the home directory.
 z <keyword>       :Jump to a directory that matches the keyword. (zoxide required)
+o                 :Open a file in a new window.
+e                 :Unpack archive/compressed file.
 dd                :Delete and yank one item.
 yy                :Yank one item.
 p                 :Put yanked item(s) in the current directory.

--- a/src/run.rs
+++ b/src/run.rs
@@ -66,7 +66,7 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
         init_log(&data_local_path)?;
     }
 
-    //Set the session file path.If not exists (i.e. first launch), create it.
+    //Set the session file path. If not exists (e.g. first launch), create it.
     let session_path = {
         let mut path = data_local_path;
         path.push(SESSION_FILE);

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,3 +1,4 @@
+use super::config::FELIX;
 use super::errors::FxError;
 use super::functions::*;
 use super::layout::{PreviewType, Split};
@@ -19,14 +20,15 @@ use std::panic;
 use std::path::PathBuf;
 use std::time::Instant;
 
-pub const TRASH: &str = "Trash";
+const TRASH: &str = "Trash";
+const SESSION_FILE: &str = ".session";
 /// Where the item list starts to scroll.
 const SCROLL_POINT: u16 = 3;
 const CLRSCR: &str = "\x1B[2J";
 const INITIAL_POS_SEARCH: usize = 3;
 const INITIAL_POS_SHELL: u16 = 3;
 
-/// Launch the app. If initializing goes wrong, return error.
+/// Launch the app. If initialization goes wrong, return error.
 pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
     //Check if argument path is valid.
     if !&arg.exists() {
@@ -66,15 +68,12 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
         init_log(&data_local_path)?;
     }
 
-    //Set the session file path. If not exists (e.g. first launch), create it.
+    //Set the session file path.
     let session_path = {
         let mut path = data_local_path;
         path.push(SESSION_FILE);
         path
     };
-    if !session_path.exists() {
-        make_session(&session_path)?;
-    }
 
     //Initialize app state. Inside State::new(), config file is read or created.
     let mut state = State::new(&session_path)?;
@@ -87,7 +86,7 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
     };
     state.is_ro = match has_write_permission(&state.current_dir) {
         Ok(b) => !b,
-        Err(_) => false
+        Err(_) => false,
     };
 
     //If the main function causes panic, catch it.

--- a/src/run.rs
+++ b/src/run.rs
@@ -97,8 +97,8 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
         arg
     };
     state.is_ro = match has_write_permission(&state.current_dir) {
-        Ok(b) => Some(b),
-        Err(_) => Some(false),
+        Ok(b) => !b,
+        Err(_) => false
     };
 
     //If the main function causes panic, catch it.

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,4 +1,3 @@
-use super::config::{make_config_if_not_exists, CONFIG_FILE};
 use super::errors::FxError;
 use super::functions::*;
 use super::layout::{PreviewType, Split};
@@ -49,25 +48,15 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
         path.push(FELIX);
         path
     };
-    if !config_dir_path.exists() {
-        std::fs::create_dir_all(&config_dir_path)?;
-    }
     if !data_local_path.exists() {
         std::fs::create_dir_all(&data_local_path)?;
     }
 
-    //Set config file and trash dir path.
-    let config_file_path = {
-        let mut path = config_dir_path;
-        path.push(CONFIG_FILE);
-        path
-    };
     let trash_dir_path = {
         let mut path = data_local_path.clone();
         path.push(TRASH);
         path
     };
-
     if !trash_dir_path.exists() {
         std::fs::create_dir_all(&trash_dir_path)?;
     }
@@ -87,8 +76,8 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
         make_session(&session_path)?;
     }
 
-    //Initialize app state.
-    let mut state = State::new(&config_file_path, &session_file_path)?;
+    //Initialize app state. Inside State::new(), config file is read or created.
+    let mut state = State::new(&session_path)?;
     state.trash_dir = trash_dir_path;
     state.current_dir = if cfg!(not(windows)) {
         // If executed this on windows, "//?" will be inserted at the beginning of the path.

--- a/src/run.rs
+++ b/src/run.rs
@@ -688,6 +688,14 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                             }
 
                                             KeyCode::Char('d') => {
+                                                //If read-only, deleting is disabled.
+                                                if state.is_ro {
+                                                    print_warning(
+                                                        "Cannot delete item in this directory.",
+                                                        state.layout.y,
+                                                    );
+                                                    continue;
+                                                }
                                                 print_info("DELETE: Processing...", state.layout.y);
                                                 let start = Instant::now();
                                                 screen.flush()?;
@@ -859,6 +867,14 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                             },
                             //delete
                             KeyCode::Char('d') => {
+                                //If read-only, deleting is disabled.
+                                if state.is_ro {
+                                    print_warning(
+                                        "Cannot delete in this directory.",
+                                        state.layout.y,
+                                    );
+                                    continue;
+                                }
                                 if len == 0 {
                                     continue;
                                 } else {
@@ -898,7 +914,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 };
                                                 let duration = duration_to_string(start.elapsed());
                                                 print_info(
-                                                    format!("1 item deleted [{}]", duration),
+                                                    format!("1 item deleted. [{}]", duration),
                                                     state.layout.y,
                                                 );
                                                 state.move_cursor(state.layout.y);
@@ -930,7 +946,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                             state.yank_item(false);
                                             go_to_and_rest_info();
                                             hide_cursor();
-                                            print_info("1 item yanked", state.layout.y);
+                                            print_info("1 item yanked.", state.layout.y);
                                         }
 
                                         _ => {
@@ -944,6 +960,14 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
 
                             //put
                             KeyCode::Char('p') => {
+                                //If read-only, putting is disabled.
+                                if state.is_ro {
+                                    print_warning(
+                                        "Cannot put into this directory.",
+                                        state.layout.y,
+                                    );
+                                    continue;
+                                }
                                 if state.registered.is_empty() {
                                     continue;
                                 }
@@ -963,9 +987,9 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                 let registered_len = state.registered.len();
                                 let mut put_message = registered_len.to_string();
                                 if registered_len == 1 {
-                                    let _ = write!(put_message, " item inserted [{}]", duration);
+                                    let _ = write!(put_message, " item inserted. [{}]", duration);
                                 } else {
-                                    let _ = write!(put_message, " items inserted [{}]", duration);
+                                    let _ = write!(put_message, " items inserted. [{}]", duration);
                                 }
                                 print_info(put_message, state.layout.y);
                             }

--- a/src/run.rs
+++ b/src/run.rs
@@ -101,6 +101,14 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
     } else {
         arg
     };
+    state.is_ro = if cfg!(not(windows)) {
+        match has_write_permission(&state.current_dir) {
+            Ok(b) => Some(b),
+            Err(_) => Some(false),
+        }
+    } else {
+        None
+    };
 
     //If the main function causes panic, catch it.
     let result = panic::catch_unwind(|| _run(state, session_file_path));

--- a/src/run.rs
+++ b/src/run.rs
@@ -101,13 +101,9 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
     } else {
         arg
     };
-    state.is_ro = if cfg!(not(windows)) {
-        match has_write_permission(&state.current_dir) {
-            Ok(b) => Some(b),
-            Err(_) => Some(false),
-        }
-    } else {
-        None
+    state.is_ro = match has_write_permission(&state.current_dir) {
+        Ok(b) => Some(b),
+        Err(_) => Some(false),
     };
 
     //If the main function causes panic, catch it.

--- a/src/run.rs
+++ b/src/run.rs
@@ -77,14 +77,14 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
         init_log(&data_local_path)?;
     }
 
-    //If session file does not exist (i.e. first launch), make it.
-    let session_file_path = {
+    //Set the session file path.If not exists (i.e. first launch), create it.
+    let session_path = {
         let mut path = data_local_path;
         path.push(SESSION_FILE);
         path
     };
-    if !session_file_path.exists() {
-        make_session(&session_file_path)?;
+    if !session_path.exists() {
+        make_session(&session_path)?;
     }
 
     //Initialize app state.
@@ -102,7 +102,7 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
     };
 
     //If the main function causes panic, catch it.
-    let result = panic::catch_unwind(|| _run(state, session_file_path));
+    let result = panic::catch_unwind(|| _run(state, session_path));
     leave_raw_mode();
 
     if let Err(panic) = result {

--- a/src/run.rs
+++ b/src/run.rs
@@ -42,13 +42,7 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
         ));
     }
 
-    //Prepare config and data local path.
-    let config_dir_path = {
-        let mut path = dirs::config_dir()
-            .ok_or_else(|| FxError::Dirs("Cannot read the config directory.".to_string()))?;
-        path.push(FELIX);
-        path
-    };
+    //Prepare data local and trash dir path.
     let data_local_path = {
         let mut path = dirs::data_local_dir()
             .ok_or_else(|| FxError::Dirs("Cannot read the data local directory.".to_string()))?;
@@ -74,8 +68,9 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
         path
     };
 
-    //Make config file and trash directory if not exists.
-    make_config_if_not_exists(&config_file_path, &trash_dir_path)?;
+    if !trash_dir_path.exists() {
+        std::fs::create_dir_all(&trash_dir_path)?;
+    }
 
     //If `-l / --log` is set, initialize logger.
     if log {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,10 +1,9 @@
-use super::errors::FxError;
 use super::layout::Split;
 use serde::{Deserialize, Serialize};
 use std::fs::read_to_string;
 use std::path::Path;
 
-pub const SESSION_FILE: &str = ".session";
+#[allow(dead_code)]
 pub const SESSION_EXAMPLE: &str = "sort_by = \"Name\"
 show_hidden = false
 preview = false
@@ -43,9 +42,4 @@ pub fn read_session(session_path: &Path) -> Session {
             split: Some(Split::Vertical),
         },
     }
-}
-
-pub fn make_session(session_file: &Path) -> Result<(), FxError> {
-    std::fs::write(session_file, SESSION_EXAMPLE)?;
-    Ok(())
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -25,23 +25,23 @@ pub enum SortKey {
     Time,
 }
 
-pub fn read_session(session_path: &Path) -> Result<Session, FxError> {
+pub fn read_session(session_path: &Path) -> Session {
     match read_to_string(session_path) {
         Ok(s) => match serde_yaml::from_str(&s) {
-            Ok(de) => Ok(de),
-            Err(_) => Ok(Session {
+            Ok(de) => de,
+            Err(_) => Session {
                 sort_by: SortKey::Name,
                 show_hidden: true,
                 preview: Some(false),
                 split: Some(Split::Vertical),
-            }),
+            },
         },
-        Err(_) => Ok(Session {
+        Err(_) => Session {
             sort_by: SortKey::Name,
             show_hidden: true,
             preview: Some(false),
             split: Some(Split::Vertical),
-        }),
+        },
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1190,13 +1190,9 @@ impl State {
 
     pub fn chdir(&mut self, p: &std::path::Path, mv: Move) -> Result<(), FxError> {
         std::env::set_current_dir(p)?;
-        self.is_ro = if cfg!(not(windows)) {
-            match has_write_permission(p) {
-                Ok(b) => Some(b),
-                Err(_) => Some(false),
-            }
-        } else {
-            None
+        self.is_ro = match has_write_permission(p) {
+            Ok(b) => Some(b),
+            Err(_) => Some(false),
         };
         match mv {
             Move::Up => {
@@ -1718,6 +1714,12 @@ pub fn has_write_permission(path: &std::path::Path) -> Result<bool, FxError> {
             }
         }
     }
+}
+
+// Currently on non-unix OS, this always return true.
+#[cfg(not(target_family = "unix"))]
+pub fn has_write_permission(_path: &std::path::Path) -> Result<bool, FxError> {
+    Ok(true)
 }
 
 #[cfg(all(target_family = "unix", not(target_os = "macos")))]

--- a/src/state.rs
+++ b/src/state.rs
@@ -91,7 +91,7 @@ impl State {
     pub fn new(session_path: &std::path::Path) -> Result<Self, FxError> {
         //Read config file.
         //Use default configuration if the file does not exist or cannot be read.
-        let config = read_or_create_config();
+        let config = read_config_or_default();
         let config = match config {
             Ok(c) => c,
             Err(e) => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -53,7 +53,7 @@ pub struct State {
     pub p_memo: Vec<StateMemo>,
     pub keyword: Option<String>,
     pub layout: Layout,
-    pub is_ro: Option<bool>,
+    pub is_ro: bool,
 }
 
 #[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -180,7 +180,7 @@ impl State {
             c_memo: Vec::new(),
             p_memo: Vec::new(),
             keyword: None,
-            is_ro: None,
+            is_ro: false,
         })
     }
 
@@ -867,7 +867,7 @@ impl State {
         }
 
         // If without the write permission, print [RO].
-        if self.is_ro == Some(false) && header_space > 5 {
+        if self.is_ro && header_space > 5 {
             set_color(&TermColor::ForeGround(&Colorname::Red));
             print!(" [RO]");
             reset_color();
@@ -1191,8 +1191,8 @@ impl State {
     pub fn chdir(&mut self, p: &std::path::Path, mv: Move) -> Result<(), FxError> {
         std::env::set_current_dir(p)?;
         self.is_ro = match has_write_permission(p) {
-            Ok(b) => Some(b),
-            Err(_) => Some(false),
+            Ok(b) => !b,
+            Err(_) => false
         };
         match mv {
             Move::Up => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -113,7 +113,7 @@ impl State {
                 Config::default()
             }
         };
-        let session = read_session(session_path)?;
+        let session = read_session(session_path);
         let (original_column, original_row) = terminal_size()?;
 
         // Return error if terminal size may cause panic

--- a/src/state.rs
+++ b/src/state.rs
@@ -1726,7 +1726,7 @@ fn in_groups(gid: u32) -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn in_groups(gid: u32) -> bool {
+fn in_groups(_gid: u32) -> bool {
     false
 }
 


### PR DESCRIPTION
## v2.3.0 (2023-05-26)

### Changed

- Add extra config file path for macOS: `/Users/$USER/.config/felix/config.yaml` will be read after `$HOME/Library/Application Support/felix/config.yaml`.
- If config file is not found, or found one is broken, felix launches with the default configuration, without creating new one.
- If the current directory is read-only, `dd`, `Vd` and `p` is disabled in the first place.
- Bump up MSRV to 1.65.

### Added

- Add `is_ro` field to `State`.

### Removed

- NetBSD install test. It often failed while setting up the VM, which had nothing with felix.