### PR TITLE
v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- Ability to `cd` {absolute/relative path}.
 - Create temp file or directory by `af` or `ad` respectively. This feature has to feel like more "modal", so for now I comment out this feature.
 
 ## v2.5.0 (2023-07-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 ### Added
 
+- Allow `<C-r>` in command line: Paste item name(s) in register. e.g. `<C-r>"` pastes item name in unnamed register.
+- Allow wild card in command line: e.g. `:zip test *.md` works now.
 - Ability to `cd` {absolute/relative path}.
+- Ability to jump backward / forward (`<C-o>`, `<C-i>` respectiely)
 - Create temp file or directory by `af` or `ad` respectively. This feature has to feel like more "modal", so for now I comment out this feature.
 
 ## v2.5.0 (2023-07-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Allow `<C-r>` in command line: Paste item name(s) in register. e.g. `<C-r>"` pastes item name in unnamed register.
 - Allow wild card in command line: e.g. `:zip test *.md` works now.
 - Ability to `cd` {absolute/relative path}.
-- Ability to jump backward / forward (`<C-o>`, `<C-i>` respectiely)
+- Ability to jump backward / forward (`<C-o>`, `<C-i>` respectively)
 - Create temp file or directory by `af` or `ad` respectively. This feature has to feel like more "modal", so for now I comment out this feature.
 
 ## v2.5.0 (2023-07-13)

--- a/src/help.rs
+++ b/src/help.rs
@@ -10,7 +10,7 @@ Both relative and absolute path available.
 ## Options
 `--help` | `-h`   => Print help.
 `--log`  | `-l`   => Launch the app, automatically generating a log file.
-`--init`          => Returns a shell script that can be sourced for shell integration.
+`--init`          => Returns a shell script that can be sourcedfor                                for shell integration.
 
 ## Manual
 j / Down          :Go down.
@@ -20,7 +20,8 @@ l / Right / Enter :Open item or change directory.
 gg                :Go to the top.
 G                 :Go to the bottom.
 z + Enter         :Go to the home directory.
-z <keyword>       :Jump to a directory that matches the keyword. (zoxide required)
+z <keyword>       :Jump to a directory that matches the keyword.
+                   (zoxide required)
 o                 :Open item in a new window.
 e                 :Unpack archive/compressed file.
 dd                :Delete and yank item.
@@ -42,7 +43,7 @@ V                 :Switch to the linewise visual mode.
 u                 :Undo put/delete/rename.
 Ctrl + r          :Redo put/delete/rename.
 v                 :Toggle whether to show the preview.
-s                 :Toggle between vertical / horizontal split in the preview mode.
+s                 :Toggle between vertical / horizontal splitin                                 in the preview mode.
 Alt + j / Down    :Scroll down the preview text.
 Alt + k / Up      :Scroll up the preview text.
 backspace         :Toggle whether to show hidden items.
@@ -59,8 +60,10 @@ Esc               :Return to the normal mode.
 :empty            :Empty the trash directory.
 :h                :Show help.
 :q                :Exit.
-ZZ                :Exit without cd to last working directory (if `match_vim_exit_behavior` is `false`).
-ZQ                :cd into the last directory and exit (if `match_vim_exit_behavior` is `false`).
+ZZ                :Exit without cd to last working directory
+                   (if `match_vim_exit_behavior` is `false`).
+ZQ                :cd into the last directory and Exit
+                   (if `match_vim_exit_behavior` is `false`).
 
 ## Preview feature
 By default, text files and directories can be previewed.

--- a/src/jumplist.rs
+++ b/src/jumplist.rs
@@ -12,9 +12,9 @@ impl JumpList {
             for _i in 0..self.pos {
                 self.list.pop_front();
             }
+            self.pos = 0;
         }
         self.list.push_front(p.to_path_buf());
-        self.pos = 0;
     }
 
     pub fn get_backward(&self) -> Option<PathBuf> {
@@ -26,7 +26,9 @@ impl JumpList {
     }
 
     pub fn pos_backward(&mut self) {
-        self.pos += 1;
+        if self.pos < self.list.len() {
+            self.pos += 1;
+        }
     }
 
     pub fn get_forward(&self) -> Option<PathBuf> {
@@ -38,7 +40,9 @@ impl JumpList {
     }
 
     pub fn pos_forward(&mut self) {
-        self.pos -= 1;
+        if self.pos > 0 {
+            self.pos -= 1;
+        }
     }
 
     pub fn remove_backward(&mut self) {

--- a/src/jumplist.rs
+++ b/src/jumplist.rs
@@ -1,0 +1,51 @@
+use std::{collections::VecDeque, path::Path, path::PathBuf};
+
+#[derive(Debug, Default)]
+pub struct JumpList {
+    pub pos: usize,
+    pub list: VecDeque<PathBuf>,
+}
+
+impl JumpList {
+    pub fn add(&mut self, p: &Path) {
+        if self.pos != 0 {
+            for _i in 0..self.pos {
+                self.list.pop_front();
+            }
+        }
+        self.list.push_front(p.to_path_buf());
+        self.pos = 0;
+    }
+
+    pub fn get_backward(&self) -> Option<PathBuf> {
+        if self.pos >= self.list.len() - 1 {
+            None
+        } else {
+            self.list.get(self.pos + 1).cloned()
+        }
+    }
+
+    pub fn pos_backward(&mut self) {
+        self.pos += 1;
+    }
+
+    pub fn get_forward(&self) -> Option<PathBuf> {
+        if self.pos == 0 {
+            None
+        } else {
+            self.list.get(self.pos - 1).cloned()
+        }
+    }
+
+    pub fn pos_forward(&mut self) {
+        self.pos -= 1;
+    }
+
+    pub fn remove_backward(&mut self) {
+        self.list.remove(self.pos + 1);
+    }
+
+    pub fn remove_forward(&mut self) {
+        self.list.remove(self.pos - 1);
+    }
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -127,10 +127,7 @@ impl Layout {
 
     /// Print preview according to the preview type.
     pub fn print_preview(&self, item: Option<&ItemInfo>, y: u16) {
-        if item.is_none() {
-            return;
-        } else {
-            let item = item.unwrap();
+        if let Some(item) = item {
             match self.split {
                 Split::Vertical => {
                     //At least print the item name

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 mod errors;
 mod functions;
 mod help;
+mod jumplist;
 mod layout;
 mod magic_image;
 mod magic_packed;

--- a/src/nums.rs
+++ b/src/nums.rs
@@ -15,6 +15,7 @@ pub enum Move {
     Up,
     Down,
     Jump,
+    List,
 }
 
 impl Num {

--- a/src/run.rs
+++ b/src/run.rs
@@ -1792,6 +1792,32 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                         state.empty_trash(&screen)?;
                                                         break 'command;
                                                     }
+                                                } else if commands.len() == 2 && command == "cd" {
+                                                    if let Ok(target) =
+                                                        std::path::Path::new(commands[1])
+                                                            .canonicalize()
+                                                    {
+                                                        if target.exists() {
+                                                            if let Err(e) =
+                                                                state.chdir(&target, Move::Jump)
+                                                            {
+                                                                print_warning(e, state.layout.y);
+                                                            }
+                                                            break 'command;
+                                                        } else {
+                                                            print_warning(
+                                                                "Path does not exist.",
+                                                                state.layout.y,
+                                                            );
+                                                            break 'command;
+                                                        }
+                                                    } else {
+                                                        print_warning(
+                                                            "Path does not exist.",
+                                                            state.layout.y,
+                                                        );
+                                                        break 'command;
+                                                    }
                                                 }
 
                                                 //Execute command as is

--- a/src/run.rs
+++ b/src/run.rs
@@ -254,7 +254,8 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                             }
                         }
 
-                        //Other commands are disabled when Ctrl is pressed.
+                        //Other commands are disabled when Ctrl is pressed,
+                        //except <C-i> (equivalent to Tab).
                         _ => {
                             continue;
                         }

--- a/src/run.rs
+++ b/src/run.rs
@@ -147,7 +147,7 @@ pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
 /// For subsequent use by cd in the parent shell
 fn export_lwd(state: &State) -> Result<(), ()> {
     if let Some(lwd_file) = &state.lwd_file {
-        std::fs::write(lwd_file, state.current_dir.to_str().unwrap()).or_else(|_| {
+        std::fs::write(lwd_file, state.current_dir.to_str().unwrap()).map_err(|_| {
             print_warning(
                 format!(
                     "Couldn't write the LWD to file {0}!",
@@ -155,14 +155,10 @@ fn export_lwd(state: &State) -> Result<(), ()> {
                 ),
                 state.layout.y,
             );
-            Err(())
         })
     } else {
-        print_warning(
-            "Shell integration may not be configured.",
-            state.layout.y,
-        );
-        return Err(());
+        print_warning("Shell integration may not be configured.", state.layout.y);
+        Err(())
     }
 }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

- Allow `<C-r>` in command line: Paste item name(s) in register. e.g. `<C-r>"` pastes item name in unnamed register.
- Allow wild card in command line: e.g. `:zip test *.md` works now.
- Allow `:cd <absolute/relative path>`.
- Ability to jump backward / forward (`<C-o>`, `<C-i>` respectively)