### PR TITLE
v2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+## v2.11.1 (2023-12-10)
+
+### Fixed
+
+- Allow SHIFT key to enter characters after `i`, `I`, `c`, `/`, `:` and `z`.
+
 ## v2.11.0 (2023-12-09)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "felix"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "bwrap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felix"
-version = "2.11.0"
+version = "2.11.1"
 authors = ["Kyohei Uto <im@kyoheiu.dev>"]
 edition = "2021"
 description = "tui file manager with vim-like key mapping"

--- a/README.md
+++ b/README.md
@@ -25,11 +25,18 @@ For more detailed document, visit https://kyoheiu.dev/felix.
 
 ## New release
 
+## v2.11.1 (2023-12-10)
+
+### Fixed
+
+- Allow SHIFT key to enter characters after `i`, `I`, `c`, `/`, `:` and `z`.
+
 ## v2.11.0 (2023-12-09)
 
 ### Added
 
 - `<C-h>` for Backspace functionality after `i`, `I`, `c`, `/`, `:` and `z`.
+
 ## v2.10.2 (2023-11-26)
 
 ### Fixed

--- a/src/run.rs
+++ b/src/run.rs
@@ -766,7 +766,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 }
                                             }
 
-                                            (KeyCode::Char(c), KeyModifiers::NONE) => {
+                                            (KeyCode::Char(c), _) => {
                                                 command.insert(
                                                     (current_pos - INITIAL_POS_Z).into(),
                                                     c,
@@ -922,28 +922,6 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 }
                                             }
 
-                                            (KeyCode::Char(c), KeyModifiers::NONE) => {
-                                                if let Some(to_be_added) =
-                                                    unicode_width::UnicodeWidthChar::width(c)
-                                                {
-                                                    if current_pos + to_be_added as u16
-                                                        > state.layout.terminal_column
-                                                    {
-                                                        continue;
-                                                    }
-                                                    new_name.insert(current_char_pos, c);
-                                                    current_char_pos += 1;
-                                                    current_pos += to_be_added as u16;
-
-                                                    go_to_info_line_and_reset();
-                                                    print!(
-                                                        " {}",
-                                                        &new_name.iter().collect::<String>(),
-                                                    );
-                                                    move_to(current_pos, 2);
-                                                }
-                                            }
-
                                             (KeyCode::Enter, KeyModifiers::NONE) => {
                                                 hide_cursor();
                                                 //Set the command and argument(s).
@@ -966,6 +944,28 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 }
                                                 state.reload(state.layout.y)?;
                                                 break 'insert;
+                                            }
+
+                                            (KeyCode::Char(c), _) => {
+                                                if let Some(to_be_added) =
+                                                    unicode_width::UnicodeWidthChar::width(c)
+                                                {
+                                                    if current_pos + to_be_added as u16
+                                                        > state.layout.terminal_column
+                                                    {
+                                                        continue;
+                                                    }
+                                                    new_name.insert(current_char_pos, c);
+                                                    current_char_pos += 1;
+                                                    current_pos += to_be_added as u16;
+
+                                                    go_to_info_line_and_reset();
+                                                    print!(
+                                                        " {}",
+                                                        &new_name.iter().collect::<String>(),
+                                                    );
+                                                    move_to(current_pos, 2);
+                                                }
                                             }
 
                                             _ => continue,
@@ -1293,7 +1293,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 }
                                             }
 
-                                            (KeyCode::Char(c), KeyModifiers::NONE) => {
+                                            (KeyCode::Char(c), _) => {
                                                 if let Some(to_be_added) =
                                                     unicode_width::UnicodeWidthChar::width(c)
                                                 {
@@ -1432,7 +1432,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 }
                                             }
 
-                                            (KeyCode::Char(c), KeyModifiers::NONE) => {
+                                            (KeyCode::Char(c), _) => {
                                                 if let Some(to_be_added) =
                                                     unicode_width::UnicodeWidthChar::width(c)
                                                 {
@@ -2048,28 +2048,6 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 }
                                             }
 
-                                            (KeyCode::Char(c), KeyModifiers::NONE) => {
-                                                if let Some(to_be_added) =
-                                                    unicode_width::UnicodeWidthChar::width(c)
-                                                {
-                                                    if current_pos + to_be_added as u16
-                                                        > state.layout.terminal_column
-                                                    {
-                                                        continue;
-                                                    }
-                                                    command.insert(current_char_pos, c);
-                                                    current_char_pos += 1;
-                                                    current_pos += to_be_added as u16;
-
-                                                    go_to_info_line_and_reset();
-                                                    print!(
-                                                        ":{}",
-                                                        &command.iter().collect::<String>(),
-                                                    );
-                                                    move_to(current_pos, 2);
-                                                }
-                                            }
-
                                             (KeyCode::Enter, KeyModifiers::NONE) => {
                                                 hide_cursor();
                                                 //Set the command and argument(s).
@@ -2226,6 +2204,28 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 info!("SHELL: {:?}", commands);
                                                 state.reload(state.layout.y)?;
                                                 break 'command;
+                                            }
+
+                                            (KeyCode::Char(c), _) => {
+                                                if let Some(to_be_added) =
+                                                    unicode_width::UnicodeWidthChar::width(c)
+                                                {
+                                                    if current_pos + to_be_added as u16
+                                                        > state.layout.terminal_column
+                                                    {
+                                                        continue;
+                                                    }
+                                                    command.insert(current_char_pos, c);
+                                                    current_char_pos += 1;
+                                                    current_pos += to_be_added as u16;
+
+                                                    go_to_info_line_and_reset();
+                                                    print!(
+                                                        ":{}",
+                                                        &command.iter().collect::<String>(),
+                                                    );
+                                                    move_to(current_pos, 2);
+                                                }
                                             }
 
                                             _ => continue,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
## v2.11.1 (2023-12-10)

### Fixed

- Allow SHIFT key to enter characters after `i`, `I`, `c`, `/`, `:` and `z`.