### PR TITLE
Add choosefiles mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,7 @@ fn main() -> Result<(), errors::FxError> {
             _ => {
                 if args[1].starts_with("--choosefiles=") {
                     let target_path = PathBuf::from(args[1].split('=').nth(1).unwrap());
-                    if !target_path.exists() {
-                        eprintln!("Target path does not exists.");
-                    } else if let Err(e) = run::run(
+                     if let Err(e) = run::run(
                         std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
                         false,
                         Some(target_path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), errors::FxError> {
             _ => {
                 if args[1].starts_with("--choosefiles=") {
                     let target_path = PathBuf::from(args[1].split('=').nth(1).unwrap());
-                     if let Err(e) = run::run(
+                    if let Err(e) = run::run(
                         std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
                         false,
                         Some(target_path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ fn main() -> Result<(), errors::FxError> {
             if let Err(e) = run::run(
                 std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
                 false,
+                None,
             ) {
                 eprintln!("{}", e);
             }
@@ -37,6 +38,7 @@ fn main() -> Result<(), errors::FxError> {
                 if let Err(e) = run::run(
                     std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
                     true,
+                    None,
                 ) {
                     eprintln!("{}", e);
                 }
@@ -45,14 +47,25 @@ fn main() -> Result<(), errors::FxError> {
                 print!("{}", shell::INTEGRATION_CODE);
             }
             _ => {
-                if let Err(e) = run::run(PathBuf::from(&args[1]), false) {
+                if args[1].starts_with("--choosefiles=") {
+                    let target_path = PathBuf::from(args[1].split('=').nth(1).unwrap());
+                    if !target_path.exists() {
+                        eprintln!("Target path does not exists.");
+                    } else if let Err(e) = run::run(
+                        std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                        false,
+                        Some(target_path),
+                    ) {
+                        eprintln!("{}", e);
+                    }
+                } else if let Err(e) = run::run(PathBuf::from(&args[1]), false, None) {
                     eprintln!("{}", e);
                 }
             }
         },
         3 => {
             if args[1] == "-l" || args[1] == "--log" {
-                if let Err(e) = run::run(PathBuf::from(&args[2]), true) {
+                if let Err(e) = run::run(PathBuf::from(&args[2]), true, None) {
                     eprintln!("{}", e);
                 }
             } else {

--- a/src/run.rs
+++ b/src/run.rs
@@ -491,7 +491,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                             if let Some(target_path) = &state.choosefiles_target {
                                                 match std::fs::File::options()
                                                     .append(true)
-                                                    .create_new(true)
+                                                    .create(true)
                                                     .open(target_path)
                                                 {
                                                     Err(e) => print_warning(e, state.layout.y),

--- a/src/run.rs
+++ b/src/run.rs
@@ -478,19 +478,49 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
 
                             //Open file or change directory
                             KeyCode::Char('l') | KeyCode::Enter | KeyCode::Right => {
-                                //In visual mode, this is disabled.
+                                //In visual mode, if not with the choosefiles option, this is disabled.
                                 if state.v_start.is_some() {
-                                    continue;
+                                    if let Some(target_path) = &state.choosefiles_target {
+                                        match std::fs::File::options()
+                                            .write(true)
+                                            .truncate(true)
+                                            .create(true)
+                                            .open(target_path)
+                                        {
+                                            Err(e) => print_warning(e, state.layout.y),
+                                            Ok(mut f) => {
+                                                let items: Vec<&str> = state
+                                                    .list
+                                                    .iter()
+                                                    .filter(|item| item.selected)
+                                                    .filter_map(|item| {
+                                                        item.file_path.as_os_str().to_str()
+                                                    })
+                                                    .collect();
+                                                let file_names = &items.join("\n");
+
+                                                if let Err(e) = writeln!(&mut f, "{}", file_names) {
+                                                    print_warning(e, state.layout.y);
+                                                } else {
+                                                    break 'main;
+                                                }
+                                            }
+                                        }
+                                        continue;
+                                    } else {
+                                        continue;
+                                    }
                                 }
                                 let mut dest: Option<PathBuf> = None;
                                 if let Ok(item) = state.get_item() {
                                     match item.file_type {
                                         FileType::File => {
-                                            // choosefiles mode appends the file path
+                                            // with choosefiles option, writes the file path
                                             // to the target file
                                             if let Some(target_path) = &state.choosefiles_target {
                                                 match std::fs::File::options()
-                                                    .append(true)
+                                                    .write(true)
+                                                    .truncate(true)
                                                     .create(true)
                                                     .open(target_path)
                                                 {

--- a/src/run.rs
+++ b/src/run.rs
@@ -491,6 +491,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                             if let Some(target_path) = &state.choosefiles_target {
                                                 match std::fs::File::options()
                                                     .append(true)
+                                                    .create_new(true)
                                                     .open(target_path)
                                                 {
                                                     Err(e) => print_warning(e, state.layout.y),
@@ -502,10 +503,7 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                         ) {
                                                             print_warning(e, state.layout.y);
                                                         } else {
-                                                            print_info(
-                                                                "Path written to the file.",
-                                                                state.layout.y,
-                                                            );
+                                                            break 'main;
                                                         }
                                                     }
                                                 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -61,6 +61,7 @@ pub struct State {
     pub layout: Layout,
     pub v_start: Option<usize>,
     pub is_ro: bool,
+    pub choosefiles_target: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -328,6 +329,7 @@ impl State {
             keyword: None,
             v_start: None,
             is_ro: false,
+            choosefiles_target: None,
         })
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
Implemented #261 

`fx --choosefiles=/path/to/textfile` or `fx --choosefiles=relative/path` launch felix with the choosefiles mode, in which opening file will add the file path to the text file.