### PR TITLE
Update Cargo.lock for 2.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "felix"
-version = "2.12.1"
+version = "2.13.0"
 dependencies = [
  "bwrap",
  "chrono",


### PR DESCRIPTION
I'm not sure why the CI didn't catch this
