### PR TITLE
Fix: test fails in chroot environment

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -2052,19 +2052,17 @@ mod tests {
     fn test_has_write_permission() {
         // chmod to 444 and check if it's read-only
         let p = std::path::PathBuf::from("./testfiles/permission_test");
-        let _status = std::process::Command::new("chmod")
-            .args(["444", "./testfiles/permission_test"])
-            .status()
-            .unwrap();
+        let mut perms = std::fs::metadata(&p).unwrap().permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(&p, perms.clone()).unwrap();
         assert!(!has_write_permission(p.as_path()).unwrap());
-        let _status = std::process::Command::new("chmod")
-            .args(["755", "./testfiles/permission_test"])
-            .status()
-            .unwrap();
 
-        // Test the home directory, which should pass
         let home_dir = dirs::home_dir().unwrap();
         assert!(has_write_permission(&home_dir).unwrap());
+
+        // Set the file writable
+        perms.set_readonly(false);
+        std::fs::set_permissions(&p, perms).unwrap();
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -2050,13 +2050,16 @@ mod tests {
 
     #[test]
     fn test_has_write_permission() {
-        // chmod to 444 and check if it's read-only
         let p = std::path::PathBuf::from("./testfiles/permission_test");
+        assert!(has_write_permission(&p).unwrap());
+
+        // chmod to 444 and check if it's read-only
         let mut perms = std::fs::metadata(&p).unwrap().permissions();
         perms.set_readonly(true);
         std::fs::set_permissions(&p, perms.clone()).unwrap();
-        assert!(!has_write_permission(p.as_path()).unwrap());
+        assert!(!has_write_permission(&p).unwrap());
 
+        // HOME_DIR should pass as writable
         let home_dir = dirs::home_dir().unwrap();
         assert!(has_write_permission(&home_dir).unwrap());
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
- Use `set_readonly` instead of calling `chmod`