### PR TITLE
feat: add configurable icon rendering system (Nerd Font support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,10 +385,12 @@ dependencies = [
  "normpath",
  "rayon",
  "serde",
+ "serde_json",
  "serde_yaml",
  "simplelog",
  "tar",
  "tempfile",
+ "toml",
  "unicode-width 0.2.0",
  "walkdir",
  "zip",
@@ -476,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hmac"
@@ -654,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1059,22 +1061,54 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1289,6 +1323,45 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "typenum"
@@ -1677,6 +1750,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +1909,12 @@ dependencies = [
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ unicode-width = "0.2.0"
 git2 = {version = "0.19.0", default-features = false }
 normpath = "1.3.0"
 tempfile = "3.15.0"
+serde_json = "1.0.150"
+toml = "1.1.2"
 
 [dev-dependencies]
 bwrap = { version = "1.3.0", features = ["use_std"] }

--- a/config.yaml
+++ b/config.yaml
@@ -45,3 +45,16 @@
 #   file_fg: LightWhite
 #   symlink_fg: LightYellow
 #   dirty_fg: Red
+
+# Whether to disable icons (Nerd Font expected for them to work as intended)
+# disable_icons: true
+
+# Path to an icon map in JSON/TOML format
+# File must have the following structure:
+# { types: {folder, symlink, file, error}, extensions: {ext -> icon} }
+# "ext" is case-insensitive and can either be in ".ext" or "ext" format.
+# Duplicate ext entries will result in last-write-wins (order is undefined)
+# Example path: "~/.config/felix/map.json"
+# If this field is left undefined, but icons aren't disabled felix will use an
+# embedded default mapping (type icons only with no extension icons).
+# icon_map: ~/.config/felix/map.json

--- a/iconmap.json
+++ b/iconmap.json
@@ -1,0 +1,9 @@
+{
+  "types": {
+    "folder": "\uf4d3",
+    "symlink": "\uf504",
+    "file": "\uf15b",
+    "error": "\ue654"
+  },
+  "extensions": {}
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,8 @@ pub struct Config {
     pub exec: Option<BTreeMap<String, Vec<String>>>,
     pub ignore_case: Option<bool>,
     pub color: Option<ConfigColor>,
+    pub disable_icons: Option<bool>,
+    pub icon_map: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -73,6 +75,8 @@ impl Default for Config {
             exec: Default::default(),
             ignore_case: Some(false),
             color: Some(Default::default()),
+            disable_icons: Some(false),
+            icon_map: None,
         }
     }
 }
@@ -156,6 +160,8 @@ mod tests {
         assert_eq!(default_config.exec, None);
         assert_eq!(default_config.ignore_case, None);
         assert_eq!(default_config.color, None);
+        assert_eq!(default_config.disable_icons, None);
+        assert_eq!(default_config.icon_map, None);
     }
 
     #[test]
@@ -175,6 +181,8 @@ color:
   file_fg: LightWhite
   symlink_fg: LightYellow
   dirty_fg: Red
+disable_icons: true
+icon_map: /test/icons.json
 "#,
         )
         .unwrap();
@@ -209,5 +217,7 @@ color:
             Colorname::LightYellow
         );
         assert_eq!(full_config.color.unwrap().dirty_fg, Colorname::Red);
+        assert_eq!(full_config.disable_icons, Some(true));
+        assert_eq!(full_config.icon_map, Some("/test/icons.json".to_string()));
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -17,6 +17,8 @@ use crossterm::event::{Event, KeyCode, KeyEvent};
 use crossterm::style::Stylize;
 use log::info;
 use normpath::PathExt;
+use serde::Deserialize;
+use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
@@ -45,6 +47,24 @@ pub const EMPTY_WARNING: &str = "Are you sure to empty the trash directory? (if 
 const MAX_SIZE_TO_PREVIEW: u64 = 1_000_000_000;
 const MAX_SIZE_TO_PREVIEW_TEXT: u64 = 1_000_000;
 
+const DEFAULT_ICON_MAP_JSON: &str = include_str!("../iconmap.json");
+
+#[derive(Deserialize, Debug, Default)]
+pub struct IconMap {
+    types: TypeIcons,
+
+    #[serde(default)]
+    extensions: HashMap<String, String>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+struct TypeIcons {
+    folder: String,
+    symlink: String,
+    file: String,
+    error: String,
+}
+
 #[derive(Debug, Default)]
 pub struct State {
     pub list: Vec<ItemInfo>,
@@ -66,6 +86,8 @@ pub struct State {
     pub layout: Layout,
     pub v_start: Option<usize>,
     pub is_ro: bool,
+    pub render_icons: bool,
+    pub icon_map: IconMap,
 }
 
 #[derive(Debug, Default)]
@@ -213,6 +235,7 @@ impl ItemBuffer {
 pub struct ItemInfo {
     pub file_type: FileType,
     pub file_name: String,
+    pub file_icon: String,
     pub file_path: std::path::PathBuf,
     pub symlink_dir_path: Option<PathBuf>,
     pub file_size: u64,
@@ -272,6 +295,57 @@ impl State {
         self.ignore_case = config.ignore_case;
         let colors = config.color.unwrap_or_default();
         self.layout.colors = colors;
+
+        // Decide if icons are disabled (requires a Nerd Font)
+        let disable_icons = config.disable_icons.unwrap_or(false);
+        self.render_icons = !disable_icons;
+        self.icon_map = if disable_icons {
+            IconMap::default()
+        } else {
+            config
+                .icon_map
+                .as_deref()
+                .map(Self::load_icon_map)
+                .unwrap_or_else(Self::load_default_icon_map)
+        };
+    }
+
+    fn load_icon_map(path: &str) -> IconMap {
+        let data = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("Failed to read icon map at {path}: {e}");
+                return Self::load_default_icon_map();
+            }
+        };
+        let parse_json = |s: &str| serde_json::from_str::<IconMap>(s).map_err(|e| e.to_string());
+        let parse_toml = |s: &str| toml::from_str::<IconMap>(s).map_err(|e| e.to_string());
+
+        let map = match std::path::Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+            .as_deref()
+        {
+            Some("json") => parse_json(&data),
+            Some("toml") => parse_toml(&data),
+            _ => parse_json(&data).or_else(|json_err| {
+                parse_toml(&data).map_err(|toml_err| format!("JSON: {json_err}, TOML: {toml_err}"))
+            }),
+        };
+
+        match map {
+            Ok(m) => m,
+            Err(e) => {
+                log::warn!("Failed to parse icon map at {path}: {e}");
+                Self::load_default_icon_map()
+            }
+        }
+    }
+
+    fn load_default_icon_map() -> IconMap {
+        // Safe: covered by 'default_icon_map_is_valid()'.
+        serde_json::from_str(DEFAULT_ICON_MAP_JSON).expect("embedded iconmap.json is invalid")
     }
 
     /// Select item that the cursor points to.
@@ -1096,6 +1170,15 @@ impl State {
 
     /// Print an item in the directory.
     fn print_item(&self, item: &ItemInfo) {
+        // If icons are loaded use them else don't
+        let print_name = |name| {
+            if self.render_icons {
+                print!("{} {}", item.file_icon, name);
+            } else {
+                print!("{}", name);
+            }
+        };
+
         let name = if item.file_name.bytes().len() <= self.layout.name_max_len {
             item.file_name.clone()
         } else {
@@ -1117,15 +1200,15 @@ impl State {
         if self.layout.terminal_column < PROPER_WIDTH {
             if item.selected {
                 set_color(&TermColor::ForeGround(color));
-                print!("{}", name.negative(),);
+                print_name(name.negative());
                 reset_color();
             } else if item.matches {
                 set_color(&TermColor::ForeGround(color));
-                print!("{}", name.bold(),);
+                print_name(name.bold());
                 reset_color();
             } else {
                 set_color(&TermColor::ForeGround(color));
-                print!("{}", name);
+                print_name(name.stylize());
                 reset_color();
             }
             if self.layout.terminal_column > self.layout.time_start_pos + TIME_WIDTH {
@@ -1133,14 +1216,14 @@ impl State {
             }
         } else if item.selected {
             set_color(&TermColor::ForeGround(color));
-            print!("{}", name.negative(),);
+            print_name(name.negative());
             move_left(1000);
             move_right(self.layout.time_start_pos - 1);
             print!(" {}", time.negative());
             reset_color();
         } else if item.matches {
             set_color(&TermColor::ForeGround(color));
-            print!("{}", name.bold(),);
+            print_name(name.bold());
             move_left(1000);
             move_right(self.layout.time_start_pos - 1);
             set_color(&TermColor::ForeGround(color));
@@ -1148,7 +1231,7 @@ impl State {
             reset_color();
         } else {
             set_color(&TermColor::ForeGround(color));
-            print!("{}", name);
+            print_name(name.stylize());
             move_left(1000);
             move_right(self.layout.time_start_pos - 1);
             print!(" {}", time);
@@ -1211,7 +1294,7 @@ impl State {
 
         for entry in fs::read_dir(&self.current_dir)? {
             let e = entry?;
-            let mut entry = read_item(e);
+            let mut entry = read_item(&self.icon_map, e);
             if dirty_paths.contains(&entry.file_path) {
                 entry.is_dirty = true;
             }
@@ -1836,8 +1919,19 @@ impl State {
     }
 }
 
+fn get_icon(map: &IconMap, file_type: FileType, ext: Option<&str>) -> String {
+    match file_type {
+        FileType::Directory => map.types.folder.clone(),
+        FileType::Symlink => map.types.symlink.clone(),
+        FileType::File => ext
+            .and_then(|e| map.extensions.get(e))
+            .cloned()
+            .unwrap_or_else(|| map.types.file.clone()),
+    }
+}
+
 /// Read item information from `std::fs::DirEntry`.
-fn read_item(entry: fs::DirEntry) -> ItemInfo {
+fn read_item(map: &IconMap, entry: fs::DirEntry) -> ItemInfo {
     let path = entry.path();
     let metadata = fs::symlink_metadata(&path);
 
@@ -1876,6 +1970,8 @@ fn read_item(entry: fs::DirEntry) -> ItemInfo {
                 }
             };
 
+            let icon = get_icon(map, filetype, ext.as_deref());
+
             let sym_dir_path = {
                 if filetype == FileType::Symlink {
                     if let Ok(sym_meta) = fs::metadata(&path) {
@@ -1901,6 +1997,7 @@ fn read_item(entry: fs::DirEntry) -> ItemInfo {
             ItemInfo {
                 file_type: filetype,
                 file_name: name,
+                file_icon: icon,
                 file_path: path,
                 symlink_dir_path: sym_dir_path,
                 file_size: size,
@@ -1922,6 +2019,7 @@ fn read_item(entry: fs::DirEntry) -> ItemInfo {
         Err(_) => ItemInfo {
             file_type: FileType::File,
             file_name: name,
+            file_icon: map.types.error.clone(),
             file_path: path,
             symlink_dir_path: None,
             file_size: 0,
@@ -2058,7 +2156,7 @@ mod tests {
         let mut file_v = Vec::new();
         for entry in fs::read_dir("src")? {
             let e = entry?;
-            let entry = read_item(e);
+            let entry = read_item(&IconMap::default(), e);
             match entry.file_type {
                 FileType::Directory => dir_v.push(entry),
                 FileType::File | FileType::Symlink => file_v.push(entry),
@@ -2075,8 +2173,8 @@ mod tests {
             let e = entry?;
             temp.push(e);
         }
-
-        let temp: Vec<ItemInfo> = temp.into_par_iter().map(read_item).collect();
+        let icons = IconMap::default();
+        let temp: Vec<ItemInfo> = temp.into_par_iter().map(|e| read_item(&icons, e)).collect();
 
         for entry in temp {
             match entry.file_type {
@@ -2124,5 +2222,11 @@ mod tests {
             bench_update2().unwrap();
         });
         bench_result.print_stats();
+    }
+
+    #[test]
+    fn default_icon_map_is_valid() {
+        // Ensure the embedded icon map (DEFAULT_ICON_MAP_JSON) is valid
+        let _: IconMap = serde_json::from_str(DEFAULT_ICON_MAP_JSON).unwrap();
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -65,6 +65,26 @@ struct TypeIcons {
     error: String,
 }
 
+impl IconMap {
+    /// Normalizes extension mapping to lowercase and ext dots (so .rs = rs)
+    fn normalize_extensions(&mut self) {
+        let mut normalized = HashMap::new();
+
+        for (k, v) in std::mem::take(&mut self.extensions) {
+            let key = Self::normalize_ext(&k);
+
+            if normalized.insert(key.clone(), v).is_some() {
+                log::warn!("Duplicate icon mapping for extension '{key}'");
+            }
+        }
+        self.extensions = normalized;
+    }
+
+    fn normalize_ext(ext: &str) -> String {
+        ext.trim_start_matches(".").to_ascii_lowercase()
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct State {
     pub list: Vec<ItemInfo>,
@@ -308,6 +328,8 @@ impl State {
                 .map(Self::load_icon_map)
                 .unwrap_or_else(Self::load_default_icon_map)
         };
+        // Must call after setting self.icon_map to ensure normalization
+        self.icon_map.normalize_extensions();
     }
 
     fn load_icon_map(path: &str) -> IconMap {
@@ -1924,7 +1946,8 @@ fn get_icon(map: &IconMap, file_type: FileType, ext: Option<&str>) -> String {
         FileType::Directory => map.types.folder.clone(),
         FileType::Symlink => map.types.symlink.clone(),
         FileType::File => ext
-            .and_then(|e| map.extensions.get(e))
+            .map(IconMap::normalize_ext)
+            .and_then(|e| map.extensions.get(&e))
             .cloned()
             .unwrap_or_else(|| map.types.file.clone()),
     }


### PR DESCRIPTION
## Configurable Icon Rendering System

**Summary**
This PR introduces a configurable icon rendering system (intended for use with Nerd Fonts, but any string-based icon is supported). 
By default, it provides basic “type icons” for directories, symlinks, files, and error states (e.g. metadata read failures). This can be extended via a user-provided icon map in either JSON or TOML format.
I opted not to include a large default extension-to-icon mapping to avoid adding maintenance burden or opinionated defaults; this can be extended later if needed.
If any issues occur while loading a user-provided icon map, the system will gracefully fall back to a minimal embedded type-only mapping. Users may also opt out entirely via disable_icons: true in the configuration.

**Code Changes**
- Introduced `icon_map` and `disable_icons` fields in `config.rs`
- Introduced `IconMap` and `TypeIcons` structures in `state.rs`
- Added embedded default icon map (`iconmap.json`) via `include_str!`
- Icons are enabled or disabled based on `disable_icons`. When enabled, the icon map is loaded and deserialized into state; otherwise icons are disabled.
- Added `file_icon` field to `ItemInfo`, populated during `read_item` in directory scanning
- This field is used during rendering to retrieve the appropriate icon
- Added basic tests for the new functionality

**Example user JSON map**
All values are Nerd Font glyphs encoded as Unicode escape sequences:
```json
{
  "types": {
    "folder": "\uf4d3",
    "symlink": "\uf504",
    "file": "\uf15b",
    "error": "\ue654"
  },
  "extensions": {
    "rs": "\ue7a8",
    "json": "\ueb0f",
    "toml": "\ue6b2",
    "md": "\ueda4",
    "yaml": "\ue8eb",
    "lock": "\uf023"
  }
}
```
Example output (Foot terminal, Gruvbox theme):
<img width="795" height="414" alt="image" src="https://github.com/user-attachments/assets/9e0bc833-3356-45d0-8fad-b59b83e256f7" />

**Note for Reviewers**
I am still relatively inexperienced with Rust, so the current implementation stores icons as `String`. This may be optimised in the future to reduce allocations.