### PR TITLE
feat: implement interactive file filtering using glob patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "dirs",
  "flate2",
  "git2",
+ "glob",
  "log",
  "lzma-rs",
  "natord",
@@ -473,6 +474,12 @@ dependencies = [
  "log",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ unicode-width = "0.2.0"
 git2 = {version = "0.19.0", default-features = false }
 normpath = "1.3.0"
 tempfile = "3.15.0"
+glob = "0.3.1"
 
 [dev-dependencies]
 bwrap = { version = "1.3.0", features = ["use_std"] }

--- a/src/help.rs
+++ b/src/help.rs
@@ -66,6 +66,7 @@ c                  :Switch to the rename mode.
 /{keyword}         :Search items by a keyword.
 n                  :Go forward to the item that matches the keyword.
 N                  :Go backward to the item that matches the keyword.
+f{pattern}<CR>     :Filter the view using a glob pattern.
 :                  :Switch to the command line.
   - <C-r>a         :In the command line, paste item name in register a.
 :cd<CR>            :Go to the home directory.
@@ -77,8 +78,8 @@ N                  :Go backward to the item that matches the keyword.
 :h<CR>             :Show help.
 :q<CR>             :Exit.
 :{command}         :Execute a command e.g. :zip test *.md
-<Esc>              :Return to the normal mode.
-<C-h>              :Works as Backspace after `i`, `I`, `c`, `/`, `:` and `z`.
+<Esc>              :Return to the normal mode and clear the filter.
+<C-h>              :Works as Backspace after `i`, `I`, `c`, `/`, `:`, `f` and `z`.
 ZZ                 :Exit without cd to last working directory
                     (if `match_vim_exit_behavior` is `false`).
 ZQ                 :cd into the last working directory and exit

--- a/src/run.rs
+++ b/src/run.rs
@@ -34,6 +34,7 @@ const PROMPT_INSERT_DIR: &str = "New directory: ";
 const PROMPT_RENAME: &str = "New name: ";
 const PROMPT_SEARCH: &str = "/";
 const PROMPT_COMMAND_LINE: &str = ":";
+const PROMPT_FILTER: &str = "Filter: ";
 
 /// Launch the app. If initialization goes wrong, return error.
 pub fn run(arg: PathBuf, log: bool) -> Result<(), FxError> {
@@ -442,10 +443,17 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                     },
                     KeyModifiers::NONE | KeyModifiers::SHIFT => {
                         match code {
-                            //Reset visual selection and return to normal mode
+                            //Reset visual selection, clear filter, and return to normal mode
                             KeyCode::Esc => {
                                 state.reset_selection();
-                                state.redraw(state.layout.y);
+                                if state.active_filter.is_some() {
+                                    state.active_filter = None;
+                                    state.layout.nums.reset();
+                                    state.update_list()?;
+                                    state.redraw(BEGINNING_ROW);
+                                } else {
+                                    state.redraw(state.layout.y);
+                                }
                                 continue;
                             }
 
@@ -1703,6 +1711,136 @@ fn _run(mut state: State, session_path: PathBuf) -> Result<(), FxError> {
                                                 go_to_info_line_and_reset();
                                                 state.keyword = Some(keyword.iter().collect());
                                                 state.move_cursor(state.layout.y);
+                                                break;
+                                            }
+
+                                            _ => continue,
+                                        }
+                                        screen.flush()?;
+                                    }
+                                }
+                                hide_cursor();
+                            }
+
+                            KeyCode::Char('f') => {
+                                if state.v_start.is_some() {
+                                    continue;
+                                }
+                                if len == 0 {
+                                    continue;
+                                }
+                                delete_pointer();
+                                show_cursor();
+                                go_to_info_line_and_reset();
+                                print!("{}", PROMPT_FILTER);
+                                screen.flush()?;
+
+                                let mut keyword: Vec<char> = Vec::new();
+
+                                // express position in terminal
+                                let (mut current_pos, _) = cursor_pos()?;
+                                // express position in Vec<Char>
+                                let mut current_char_pos = 0;
+                                loop {
+                                    if let Event::Key(KeyEvent {
+                                        code,
+                                        modifiers,
+                                        kind: KeyEventKind::Press,
+                                        ..
+                                    }) = event::read()?
+                                    {
+                                        match (code, modifiers) {
+                                            (KeyCode::Esc, KeyModifiers::NONE) => {
+                                                hide_cursor();
+                                                state.active_filter = None;
+                                                state.update_list()?;
+                                                state.redraw(state.layout.y);
+                                                break;
+                                            }
+
+                                            (KeyCode::Left, KeyModifiers::NONE) => {
+                                                move_left_command_line(
+                                                    &mut keyword,
+                                                    &mut current_char_pos,
+                                                    &mut current_pos,
+                                                );
+                                            }
+
+                                            (KeyCode::Right, KeyModifiers::NONE) => {
+                                                move_right_command_line(
+                                                    &mut keyword,
+                                                    &mut current_char_pos,
+                                                    &mut current_pos,
+                                                );
+                                            }
+
+                                            (KeyCode::Backspace, KeyModifiers::NONE)
+                                            | (KeyCode::Char('h'), KeyModifiers::CONTROL) => {
+                                                if current_char_pos == 0 {
+                                                    continue;
+                                                };
+                                                let removed = keyword.remove(current_char_pos - 1);
+                                                if let Some(to_be_removed) =
+                                                    unicode_width::UnicodeWidthChar::width(removed)
+                                                {
+                                                    current_char_pos -= 1;
+                                                    current_pos -= to_be_removed as u16;
+
+                                                    let key = &keyword.iter().collect::<String>();
+
+                                                    go_to_info_line_and_reset();
+                                                    print!("{}{}", PROMPT_FILTER, key);
+                                                    move_to(current_pos + 1, 2);
+                                                }
+                                            }
+
+                                            (KeyCode::Char(c), _) => {
+                                                if let Some(to_be_added) =
+                                                    unicode_width::UnicodeWidthChar::width(c)
+                                                {
+                                                    if current_pos + to_be_added as u16
+                                                        > state.layout.terminal_column
+                                                    {
+                                                        continue;
+                                                    }
+                                                    keyword.insert(current_char_pos, c);
+                                                    current_char_pos += 1;
+                                                    current_pos += to_be_added as u16;
+
+                                                    let key = &keyword.iter().collect::<String>();
+
+                                                    go_to_info_line_and_reset();
+                                                    print!("{}{}", PROMPT_FILTER, key);
+                                                    move_to(current_pos + 1, 2);
+                                                }
+                                            }
+
+                                            (KeyCode::Enter, KeyModifiers::NONE) => {
+                                                let input: String = keyword.into_iter().collect();
+                                                if input.is_empty() {
+                                                    state.active_filter = None;
+                                                    state.layout.nums.reset();
+                                                    state.update_list()?;
+                                                    state.redraw(BEGINNING_ROW);
+                                                    break;
+                                                }
+
+                                                match glob::Pattern::new(&input) {
+                                                    Ok(pattern) => {
+                                                        state.active_filter = Some(pattern);
+                                                        state.layout.nums.reset();
+                                                        state.update_list()?;
+                                                        state.redraw(BEGINNING_ROW);
+                                                    }
+                                                    Err(_) => {
+                                                        hide_cursor();
+                                                        state.redraw(state.layout.y);
+                                                        print_warning(
+                                                            "Invalid Glob Pattern",
+                                                            state.layout.y,
+                                                        );
+                                                    }
+                                                }
                                                 break;
                                             }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -66,6 +66,7 @@ pub struct State {
     pub layout: Layout,
     pub v_start: Option<usize>,
     pub is_ro: bool,
+    pub active_filter: Option<glob::Pattern>,
 }
 
 #[derive(Debug, Default)]
@@ -1072,6 +1073,15 @@ impl State {
             header_space -= 5;
         }
 
+        if let Some(ref filter) = self.active_filter {
+            let filter_str = format!(" [Filter: {}]", filter.as_str());
+            let len = filter_str.len();
+            if header_space >= len {
+                print!("{}", filter_str.bold());
+                header_space -= len;
+            }
+        }
+
         //If git repository exists, get the branch information and print it.
         if let Ok(repo) = git2::Repository::open(&self.current_dir) {
             if let Ok(head) = repo.head() {
@@ -1246,6 +1256,10 @@ impl State {
             result.retain(|x| !x.is_hidden);
         }
 
+        if let Some(ref pattern) = self.active_filter {
+            result.retain(|x| pattern.matches(&x.file_name));
+        }
+
         self.list = result;
         Ok(())
     }
@@ -1288,6 +1302,10 @@ impl State {
 
         if !self.layout.show_hidden {
             result.retain(|x| !x.is_hidden);
+        }
+
+        if let Some(ref pattern) = self.active_filter {
+            result.retain(|x| pattern.matches(&x.file_name));
         }
 
         self.list = result;


### PR DESCRIPTION
### Summar
Added glob search filtering (Eg: \*.md, src/\*)
Closes #318

### Changes
 - Added glob dependency
 - Added active_filter as a field in State
 - active_filter is filtered during update_list and reorder
 - Esc in normal mode clears the filter
 - Added `f` keybinding to open the interactive filter prompt
 - Active filter pattern is now displayed in the top UI header